### PR TITLE
fix: 修复 JWT 中间件逻辑错误

### DIFF
--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -72,15 +72,16 @@ func JWTAuthMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		// 如果 Authorization 头部信息格式不正确，或者 token 格式不正确，则返回错误
-		if len(parts) != 2 && parts[0] != "Bearer" {
-			ctx.JSON(http.StatusUnauthorized, commonModel.Fail[any](errUtil.HandleError(&commonModel.ServerError{
-				Msg: commonModel.TOKEN_NOT_VALID,
-				Err: nil,
-			})))
-			ctx.Abort()
-			return
-		}
+	// 如果 Authorization 头部信息格式不正确，或者 token 格式不正确，则返回错误
+	// YuGe: 将 &&（逻辑与）改为 ||（逻辑或），现在可以正确验证：
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		ctx.JSON(http.StatusUnauthorized, commonModel.Fail[any](errUtil.HandleError(&commonModel.ServerError{
+			Msg: commonModel.TOKEN_NOT_VALID,
+			Err: nil,
+		})))
+		ctx.Abort()
+		return
+	}
 
 		// 解析 token
 		mc, err := jwtUtil.ParseToken(parts[1])


### PR DESCRIPTION
## 修复说明

### 问题描述
JWT 中间件中的条件判断使用了错误的逻辑运算符，导致某些非法的 token 格式可以通过验证。

### 修改内容
- 文件：`internal/middleware/auth.go`（第76行）
- 将条件判断的逻辑运算符从 `&&`（逻辑与）改为 `||`（逻辑或）

**修改前：**
```go
if len(parts) != 2 && parts[0] != "Bearer" {
```

**修改后：**
```go
if len(parts) != 2 || parts[0] != "Bearer" {
```

### 影响范围
修复了一个安全问题：当 Authorization 头部格式正确（恰好为两部分）但第一部分不是 "Bearer" 时，非法的 token 格式可以绕过验证。

现在可以正确拦截以下两种情况：
- ✅ Authorization 头部不是两部分
- ✅ Authorization 头部第一部分不是 "Bearer"

### 测试
- [x] 代码编译通过
- [x] 无 linter 错误
- [x] 逻辑验证正确

### 📚 相关信息
这个修复提升了 JWT 认证的安全性，确保只有符合 `Bearer <token>` 格式的 Authorization 头部才能通过验证。