### PR TITLE
fix: 修复嵌套事务调用问题

### DIFF
--- a/internal/service/echo/echo.go
+++ b/internal/service/echo/echo.go
@@ -99,10 +99,10 @@ func (echoService *EchoService) PostEcho(userid uint, newEcho *model.Echo) error
 		for i := range newEcho.Images {
 			// 只有S3图片且有ObjectKey的才处理
 			if newEcho.Images[i].ImageSource == model.ImageSourceS3 && newEcho.Images[i].ObjectKey != "" {
-				// 直接删除临时文件记录 (开启事务)
-				echoService.txManager.Run(func(ctx context.Context) error {
-					return echoService.commonRepository.DeleteTempFileByObjectKey(ctx, newEcho.Images[i].ObjectKey)
-				})
+				// 使用外层事务的 ctx 直接调用仓储层方法
+				if err := echoService.commonRepository.DeleteTempFileByObjectKey(ctx, newEcho.Images[i].ObjectKey); err != nil {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
## 修复说明

### 问题描述
在 `PostEcho` 方法中，外层事务内部又嵌套调用了新的事务，这可能导致：
- 数据库死锁
- 事务隔离性被破坏
- 内层事务的错误被忽略

### 修改内容
- 文件：`internal/service/echo/echo.go`（第103行）
- 移除了嵌套的 `txManager.Run()` 调用
- 直接使用外层事务的 `context` 调用仓储层方法
- 添加了错误检查和返回

**修改前：**
```go
echoService.txManager.Run(func(ctx context.Context) error {
    return echoService.commonRepository.DeleteTempFileByObjectKey(ctx, newEcho.Images[i].ObjectKey)
})
```

**修改后：**
```go
if err := echoService.commonRepository.DeleteTempFileByObjectKey(ctx, newEcho.Images[i].ObjectKey); err != nil {
    return err
}
```

### 影响范围
修复了事务管理问题，现在：
- ✅ 避免了潜在的死锁风险
- ✅ 保持了事务的原子性和一致性
- ✅ 错误能够正确传播和处理

### ✅ 测试
- [x] 代码编译通过
- [x] 无 linter 错误
- [x] 事务逻辑正确