### PR TITLE
feat: 添加布局方式支持，优化图片展示逻辑

### DIFF
--- a/internal/model/echo/echo.go
+++ b/internal/model/echo/echo.go
@@ -8,6 +8,7 @@ type Echo struct {
 	Content       string    `gorm:"type:text;not null"                               json:"content"`
 	Username      string    `gorm:"type:varchar(100)"                                json:"username,omitempty"`
 	Images        []Image   `gorm:"foreignKey:MessageID;constraint:OnDelete:CASCADE" json:"images,omitempty"`
+	Layout        string    `gorm:"type:varchar(50);default:'waterfall'"             json:"layout,omitempty"`
 	Private       bool      `gorm:"default:false"                                    json:"private"`
 	UserID        uint      `gorm:"not null;index"                                   json:"user_id"`
 	Extension     string    `gorm:"type:text"                                        json:"extension,omitempty"`

--- a/internal/repository/echo/echo.go
+++ b/internal/repository/echo/echo.go
@@ -220,6 +220,7 @@ func (echoRepository *EchoRepository) UpdateEcho(ctx context.Context, echo *mode
 		Updates(map[string]interface{}{
 			"content":        echo.Content,
 			"private":        echo.Private,
+			"layout":         echo.Layout,
 			"extension":      echo.Extension,
 			"extension_type": echo.ExtensionType,
 		}).Error; err != nil {

--- a/web/src/components/advanced/TheEchoCard.vue
+++ b/web/src/components/advanced/TheEchoCard.vue
@@ -103,23 +103,47 @@
     <!-- 图片 && 内容 -->
     <div class="border-l-2 border-[#0000000d] ml-1">
       <div class="px-4 py-3">
-        <TheImageGallery :images="props.echo.images" />
+        <!-- 根据布局决定文字与图片顺序 -->
+        <!-- grid 和 horizontal 时，文字在图片上；其他布局（waterfall/carousel/null/undefined）文字在图片下 -->
+        <template v-if="props.echo.layout === 'grid' || props.echo.layout === 'horizontal'">
+          <!-- 文字在上 -->
+          <div class="mx-auto w-11/12 pl-1 mb-3">
+            <MdPreview
+              :id="previewOptions.proviewId"
+              :modelValue="props.echo.content"
+              :theme="previewOptions.theme"
+              :show-code-row-number="previewOptions.showCodeRowNumber"
+              :preview-theme="previewOptions.previewTheme"
+              :code-theme="previewOptions.codeTheme"
+              :code-style-reverse="previewOptions.codeStyleReverse"
+              :no-img-zoom-in="previewOptions.noImgZoomIn"
+              :code-foldable="previewOptions.codeFoldable"
+              :auto-fold-threshold="previewOptions.autoFoldThreshold"
+            />
+          </div>
 
-        <!-- 内容 -->
-        <div class="mx-auto w-11/12 pl-1">
-          <MdPreview
-            :id="previewOptions.proviewId"
-            :modelValue="props.echo.content"
-            :theme="previewOptions.theme"
-            :show-code-row-number="previewOptions.showCodeRowNumber"
-            :preview-theme="previewOptions.previewTheme"
-            :code-theme="previewOptions.codeTheme"
-            :code-style-reverse="previewOptions.codeStyleReverse"
-            :no-img-zoom-in="previewOptions.noImgZoomIn"
-            :code-foldable="previewOptions.codeFoldable"
-            :auto-fold-threshold="previewOptions.autoFoldThreshold"
-          />
-        </div>
+          <TheImageGallery :images="props.echo.images" :layout="props.echo.layout" />
+        </template>
+
+        <template v-else>
+          <!-- 图片在上，文字在下（瀑布流 / 单图轮播 等） -->
+          <TheImageGallery :images="props.echo.images" :layout="props.echo.layout" />
+
+          <div class="mx-auto w-11/12 pl-1 mt-3">
+            <MdPreview
+              :id="previewOptions.proviewId"
+              :modelValue="props.echo.content"
+              :theme="previewOptions.theme"
+              :show-code-row-number="previewOptions.showCodeRowNumber"
+              :preview-theme="previewOptions.previewTheme"
+              :code-theme="previewOptions.codeTheme"
+              :code-style-reverse="previewOptions.codeStyleReverse"
+              :no-img-zoom-in="previewOptions.noImgZoomIn"
+              :code-foldable="previewOptions.codeFoldable"
+              :auto-fold-threshold="previewOptions.autoFoldThreshold"
+            />
+          </div>
+        </template>
 
         <!-- 扩展内容 -->
         <div v-if="props.echo.extension" class="my-2">

--- a/web/src/components/advanced/TheEchoDetail.vue
+++ b/web/src/components/advanced/TheEchoDetail.vue
@@ -27,23 +27,47 @@
     <!-- 图片 && 内容 -->
     <div>
       <div class="py-4">
-        <TheImageGallery :images="props.echo.images" />
+        <!-- 根据布局决定文字与图片顺序 -->
+        <!-- grid 和 horizontal 时，文字在图片上；其他布局（waterfall/carousel/null/undefined）文字在图片下 -->
+        <template v-if="props.echo.layout === 'grid' || props.echo.layout === 'horizontal'">
+          <!-- 文字在上 -->
+          <div class="mb-3">
+            <MdPreview
+              :id="previewOptions.proviewId"
+              :modelValue="props.echo.content"
+              :theme="previewOptions.theme"
+              :show-code-row-number="previewOptions.showCodeRowNumber"
+              :preview-theme="previewOptions.previewTheme"
+              :code-theme="previewOptions.codeTheme"
+              :code-style-reverse="previewOptions.codeStyleReverse"
+              :no-img-zoom-in="previewOptions.noImgZoomIn"
+              :code-foldable="previewOptions.codeFoldable"
+              :auto-fold-threshold="previewOptions.autoFoldThreshold"
+            />
+          </div>
 
-        <!-- 内容 -->
-        <div>
-          <MdPreview
-            :id="previewOptions.proviewId"
-            :modelValue="props.echo.content"
-            :theme="previewOptions.theme"
-            :show-code-row-number="previewOptions.showCodeRowNumber"
-            :preview-theme="previewOptions.previewTheme"
-            :code-theme="previewOptions.codeTheme"
-            :code-style-reverse="previewOptions.codeStyleReverse"
-            :no-img-zoom-in="previewOptions.noImgZoomIn"
-            :code-foldable="previewOptions.codeFoldable"
-            :auto-fold-threshold="previewOptions.autoFoldThreshold"
-          />
-        </div>
+          <TheImageGallery :images="props.echo.images" :layout="props.echo.layout" />
+        </template>
+
+        <template v-else>
+          <!-- 图片在上，文字在下 -->
+          <TheImageGallery :images="props.echo.images" :layout="props.echo.layout" />
+
+          <div class="mt-3">
+            <MdPreview
+              :id="previewOptions.proviewId"
+              :modelValue="props.echo.content"
+              :theme="previewOptions.theme"
+              :show-code-row-number="previewOptions.showCodeRowNumber"
+              :preview-theme="previewOptions.previewTheme"
+              :code-theme="previewOptions.codeTheme"
+              :code-style-reverse="previewOptions.codeStyleReverse"
+              :no-img-zoom-in="previewOptions.noImgZoomIn"
+              :code-foldable="previewOptions.codeFoldable"
+              :auto-fold-threshold="previewOptions.autoFoldThreshold"
+            />
+          </div>
+        </template>
 
         <!-- 扩展内容 -->
         <div v-if="props.echo.extension" class="my-4">

--- a/web/src/components/advanced/TheImageGallery.vue
+++ b/web/src/components/advanced/TheImageGallery.vue
@@ -1,31 +1,106 @@
 <template>
-  <!-- 瀑布流缩略图 -->
-  <div
-    v-if="images?.length"
-    :class="[
-      'imgwidth mx-auto grid gap-2 mb-4',
-      images.length === 1 ? 'grid-cols-1 justify-items-center' : 'grid-cols-2',
-    ]"
-  >
-    <button
-      v-for="(src, idx) in images"
-      :key="idx"
-      class="bg-transparent border-0 p-0 cursor-pointer w-fit"
-      :class="getColSpan(idx, images.length)"
-      @click="openFancybox(idx)"
+  <div v-if="images?.length" class="image-gallery-container">
+    <!-- 瀑布流布局 -->
+    <div
+      v-if="layout === 'waterfall' || !layout"
+      :class="[
+        'imgwidth mx-auto grid gap-2 mb-4',
+        images.length === 1 ? 'grid-cols-1 justify-items-center' : 'grid-cols-2',
+      ]"
     >
-      <img
-        :src="props.baseUrl ? getHubImageUrl(src, props.baseUrl) : getImageUrl(src)"
-        alt="`预览图片${idx + 1}`"
-        loading="lazy"
-        class="echoimg block max-w-full h-auto"
-      />
-    </button>
+      <button
+        v-for="(src, idx) in images"
+        :key="idx"
+        class="bg-transparent border-0 p-0 cursor-pointer w-fit"
+        :class="getColSpan(idx, images.length)"
+        @click="openFancybox(idx)"
+      >
+        <img
+          :src="baseUrl ? getHubImageUrl(src, baseUrl) : getImageUrl(src)"
+          :alt="`预览图片${idx + 1}`"
+          loading="lazy"
+          class="echoimg block max-w-full h-auto"
+        />
+      </button>
+    </div>
+
+    <!-- 九宫格布局 -->
+    <div v-if="layout === 'grid'" class="imgwidth mx-auto mb-4">
+      <div class="grid grid-cols-3 gap-2">
+        <button
+          v-for="(src, idx) in displayedImages"
+          :key="idx"
+          class="bg-transparent border-0 p-0 cursor-pointer overflow-hidden aspect-square relative"
+          @click="openFancybox(idx)"
+        >
+          <img
+            :src="baseUrl ? getHubImageUrl(src, baseUrl) : getImageUrl(src)"
+            :alt="`预览图片${idx + 1}`"
+            loading="lazy"
+            class="echoimg w-full h-full object-cover"
+          />
+
+          <div v-if="extraCount > 0 && idx === 8" class="more-overlay" aria-hidden="true">
+            +{{ extraCount }}
+          </div>
+        </button>
+      </div>
+    </div>
+
+    <!-- 单图轮播布局 -->
+    <div v-if="layout === 'carousel'" class="imgwidth mx-auto mb-4">
+      <div class="carousel-container">
+        <button
+          v-if="images[carouselIndex]"
+          class="carousel-slide bg-transparent border-0 p-0 cursor-pointer w-full overflow-hidden"
+          @click="openFancybox(carouselIndex)"
+        >
+          <img
+            :src="baseUrl ? getHubImageUrl(images[carouselIndex]!, baseUrl) : getImageUrl(images[carouselIndex]!)"
+            :alt="`预览图片${carouselIndex + 1}`"
+            loading="lazy"
+            class="echoimg w-full h-auto"
+          />
+        </button>
+
+        <div v-if="images.length > 1" class="carousel-controls">
+          <button class="carousel-btn carousel-prev" @click="prevCarousel" :disabled="carouselIndex === 0">←</button>
+          <div class="carousel-indicator">{{ carouselIndex + 1 }} / {{ images.length }}</div>
+          <button class="carousel-btn carousel-next" @click="nextCarousel" :disabled="carouselIndex === images.length - 1">→</button>
+        </div>
+
+        <div v-if="images.length > 1" class="carousel-dots">
+          <button v-for="(_, idx) in images" :key="idx" class="carousel-dot" :class="{ active: idx === carouselIndex }" @click="carouselIndex = idx" />
+        </div>
+      </div>
+    </div>
+
+    <!-- 水平轮播布局 -->
+    <div v-if="layout === 'horizontal'" class="imgwidth mx-auto mb-4">
+      <div class="horizontal-scroll-container">
+        <div class="horizontal-scroll-wrapper">
+          <button
+            v-for="(src, idx) in images"
+            :key="idx"
+            class="horizontal-item bg-transparent border-0 p-0 cursor-pointer flex-shrink-0"
+            @click="openFancybox(idx)"
+          >
+            <img
+              :src="baseUrl ? getHubImageUrl(src, baseUrl) : getImageUrl(src)"
+              :alt="`预览图片${idx + 1}`"
+              loading="lazy"
+              class="echoimg h-full w-auto object-contain"
+            />
+          </button>
+        </div>
+      </div>
+      <div class="scroll-hint">← 左右滑动查看更多 →</div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, onBeforeUnmount } from 'vue'
+import { onMounted, onBeforeUnmount, ref, computed } from 'vue'
 import { getImageUrl, getHubImageUrl } from '@/utils/other'
 import { Fancybox } from '@fancyapps/ui'
 import '@fancyapps/ui/dist/fancybox/fancybox.css'
@@ -33,59 +108,76 @@ import '@fancyapps/ui/dist/fancybox/fancybox.css'
 const props = defineProps<{
   images: App.Api.Ech0.Echo['images']
   baseUrl?: string
+  layout?: 'waterfall' | 'grid' | 'carousel' | 'horizontal' | string
 }>()
 
-// const active = ref<number | null>(null)
+const baseUrl = props.baseUrl
+
+// 布局状态（来自 props.layout）
+const layout = props.layout || 'waterfall'
+
+// 轮播索引
+const carouselIndex = ref(0)
+
+// 只显示前 9 张（用于九宫格），第 9 张显示 "+N" 覆盖层
+const displayedImages = computed(() => (props.images ? props.images.slice(0, 9) : []))
+const extraCount = computed(() => (props.images ? (props.images.length > 9 ? props.images.length - 9 : 0) : 0))
+
+// 瀑布流布局：获取列跨度
 const getColSpan = (idx: number, total: number) => {
-  // 单张图片占满
   if (total === 1) return 'col-span-1 justify-self-center'
-  // 第一张在奇数张时跨两列
   if (idx === 0 && total % 2 !== 0) return 'col-span-2'
-  // 其他图片默认占一列
   return ''
 }
 
-/* ---------- Fancybox 相关 ---------- */
+// 轮播导航
+const prevCarousel = () => {
+  if (carouselIndex.value > 0) carouselIndex.value--
+}
+const nextCarousel = () => {
+  if (carouselIndex.value < (props.images ? props.images.length - 1 : 0)) carouselIndex.value++
+}
+
 function openFancybox(startIndex: number) {
-  // 构造 Fancybox 需要的 items 数组
-  const items = props.images.map((src) => ({
-    src: props.baseUrl ? getHubImageUrl(src, props.baseUrl!) : getImageUrl(src),
+  const items = (props.images || []).map((src) => ({
+    src: baseUrl ? getHubImageUrl(src, baseUrl) : getImageUrl(src),
     type: 'image' as const,
-    thumb: props.baseUrl ? getHubImageUrl(src, props.baseUrl!) : getImageUrl(src),
+    thumb: baseUrl ? getHubImageUrl(src, baseUrl) : getImageUrl(src),
   }))
 
   Fancybox.show(items, {
     theme: 'auto',
     zoomEffect: true,
     fadeEffect: true,
-    startIndex, // 从点击的那张开始
-    backdropClick: 'close', // 点击背景不关闭
-    dragToClose: true, // 启用拖拽关闭
+    startIndex,
+    backdropClick: 'close',
+    dragToClose: true,
     keyboard: {
-      Escape: 'close', // 按下 Esc 键关闭
-      ArrowRight: 'next', // 右箭头切换到下一张
-      ArrowLeft: 'prev', // 左箭头切换到上一张
-      Delete: 'close', // 删除键关闭
-      Backspace: 'close', // 退格键关闭
-      ArrowDown: 'next', // 下箭头切换到下一张
+      Escape: 'close',
+      ArrowRight: 'next',
+      ArrowLeft: 'prev',
+      Delete: 'close',
+      Backspace: 'close',
+      ArrowDown: 'next',
       ArrowUp: 'prev',
-      PageUp: 'close',
-      PageDown: 'close',
+        PageUp: 'close',
+        PageDown: 'close',
     },
   })
 }
 
 onMounted(() => {
-  // window.addEventListener('keydown', onKeyDown)
   Fancybox.bind('[data-fancybox]', {})
 })
 
-onBeforeUnmount(() => {
-  // window.removeEventListener('keydown', onKeyDown)
-})
+onBeforeUnmount(() => {})
 </script>
 
 <style scoped>
+.image-gallery-container {
+  position: relative;
+}
+
 .imgwidth {
   width: 88%;
 }
@@ -97,5 +189,37 @@ onBeforeUnmount(() => {
     0 2px 4px rgba(0, 0, 0, 0.02),
     0 4px 8px rgba(0, 0, 0, 0.02),
     0 8px 16px rgba(0, 0, 0, 0.02);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
+
+button:hover .echoimg {
+  transform: scale(1.05);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.04),
+    0 4px 8px rgba(0, 0, 0, 0.04),
+    0 8px 16px rgba(0, 0, 0, 0.04),
+    0 16px 32px rgba(0, 0, 0, 0.04);
+}
+
+/* carousel, horizontal, grid styles (copied/adapted from provided template) */
+.carousel-container { position: relative; width: 100%; }
+.carousel-slide { position: relative; width: 100%; display: block; }
+.carousel-controls { position: absolute; bottom: 12px; left: 50%; transform: translateX(-50%); display:flex; align-items:center; gap:16px; background: rgba(0,0,0,0.4); padding:8px 16px; border-radius:20px; z-index:10; }
+.carousel-btn { background-color: rgba(255,255,255,0.8); border:none; width:32px; height:32px; border-radius:50%; cursor:pointer; font-size:16px; display:flex; align-items:center; justify-content:center; transition:all 0.2s ease; color:#333 }
+.carousel-btn:hover:not(:disabled) { background-color: white; transform: scale(1.1); }
+.carousel-btn:disabled { opacity:0.5; cursor:not-allowed }
+.carousel-indicator { color:white; font-size:12px; min-width:50px; text-align:center }
+.carousel-dots { position: absolute; bottom: 60px; left:50%; transform: translateX(-50%); display:flex; gap:8px; z-index:10 }
+.carousel-dot { width:8px; height:8px; border-radius:50%; background-color: rgba(255,255,255,0.5); border:none; cursor:pointer; transition:all 0.3s ease; padding:0 }
+.carousel-dot:hover { background-color: rgba(255,255,255,0.8) }
+.carousel-dot.active { background-color: white; transform: scale(1.2) }
+
+.horizontal-scroll-container { position: relative; width:100%; overflow-x:auto; overflow-y:hidden; scroll-behavior:smooth; -webkit-overflow-scrolling: touch; scrollbar-width: thin; scrollbar-color: rgba(0,0,0,0.1) transparent }
+.horizontal-scroll-container::-webkit-scrollbar { height:4px }
+.horizontal-scroll-wrapper { display:flex; gap:8px; padding:4px 0; align-items:center }
+.horizontal-item { flex-shrink:0; height:200px; width:auto; min-width:160px; overflow:hidden }
+.scroll-hint { text-align:center; font-size:12px; color:#999; margin-top:8px; animation: hint-pulse 2s infinite }
+@keyframes hint-pulse { 0%,100%{ opacity:0.5 } 50%{ opacity:1 } }
+
+.more-overlay { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; background: rgba(0,0,0,0.45); color:#fff; font-size:20px; font-weight:600; border-radius:8px }
 </style>

--- a/web/src/stores/editor.ts
+++ b/web/src/stores/editor.ts
@@ -35,6 +35,7 @@ export const useEditorStore = defineStore('editorStore', () => {
     content: '', // 文字板块
     images: [], // 图片板块
     private: false, // 是否私密
+  layout: 'waterfall', // 图片布局方式，默认为 waterfall
     extension: null, // 拓展内容（对于扩展类型所需的数据）
     extension_type: null, // 拓展内容类型（音乐/视频/链接/GITHUB项目）
   })
@@ -100,6 +101,7 @@ export const useEditorStore = defineStore('editorStore', () => {
       content: '',
       images: [],
       private: false,
+      layout: 'waterfall',
       extension: null,
       extension_type: null,
       tags: [],
@@ -232,6 +234,7 @@ export const useEditorStore = defineStore('editorStore', () => {
         // 回填 echoToUpdate
         echoStore.echoToUpdate.content = echoToAdd.value.content
         echoStore.echoToUpdate.private = echoToAdd.value.private
+  echoStore.echoToUpdate.layout = echoToAdd.value.layout
         echoStore.echoToUpdate.images = echoToAdd.value.images
         echoStore.echoToUpdate.extension = echoToAdd.value.extension
         echoStore.echoToUpdate.extension_type = echoToAdd.value.extension_type

--- a/web/src/typings/app.d.ts
+++ b/web/src/typings/app.d.ts
@@ -62,6 +62,7 @@ declare namespace App {
         image_url: string
         image_source: string
         images: Image[]
+        layout?: string
         private: boolean
         user_id: number
         extension: string
@@ -107,6 +108,7 @@ declare namespace App {
         content: string
         images?: ImageToAdd[] | null
         tags?: TagToAdd[] | null
+        layout?: string | null
         extension?: string | null
         extension_type?: string | null
         private: boolean
@@ -118,6 +120,7 @@ declare namespace App {
         username: string
         images?: ImageToAdd[] | null
         tags?: TagToAdd[] | null
+        layout?: string | null
         private: boolean
         user_id: number
         extension?: string | null

--- a/web/src/views/home/modules/TheEditor.vue
+++ b/web/src/views/home/modules/TheEditor.vue
@@ -111,7 +111,8 @@ watch(
 
       // 1. 填充本文
       echoToAdd.value.content = echoToUpdate.value?.content || ''
-      echoToAdd.value.private = echoToUpdate.value?.private || false
+  echoToAdd.value.private = echoToUpdate.value?.private || false
+  echoToAdd.value.layout = echoToUpdate.value?.layout || 'waterfall'
 
       // 2. 填充图片
       if (echoToUpdate.value?.images && echoToUpdate.value.images.length > 0) {

--- a/web/src/views/home/modules/TheEditor/TheImageEditor.vue
+++ b/web/src/views/home/modules/TheEditor/TheImageEditor.vue
@@ -38,6 +38,17 @@
       </div>
     </div>
 
+    <!-- 布局方式选择 -->
+    <div class="mb-3 flex items-center gap-2">
+      <span class="text-gray-500">布局方式：</span>
+      <BaseSelect
+        v-model="echoToAdd.layout"
+        :options="layoutOptions"
+        class="w-32 h-7"
+        placeholder="请选择布局方式"
+      />
+    </div>
+
     <!-- 当前上传方式与状态 -->
     <div class="text-gray-300 text-sm mb-1">
       当前上传方式为
@@ -93,19 +104,29 @@
 import { useEditorStore } from '@/stores/editor'
 import { useSettingStore } from '@/stores/setting'
 import { storeToRefs } from 'pinia'
+import { ref } from 'vue'
 import { ImageSource } from '@/enums/enums'
 import Url from '@/components/icons/url.vue'
 import Upload from '@/components/icons/upload.vue'
 import Bucket from '@/components/icons/bucket.vue'
 import Addmore from '@/components/icons/addmore.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
+import BaseSelect from '@/components/common/BaseSelect.vue'
 import BaseInput from '@/components/common/BaseInput.vue'
 import TheUppy from '@/components/advanced/TheUppy.vue'
 
 const editorStore = useEditorStore()
-const { imageToAdd, ImageUploading } = storeToRefs(editorStore)
+const { imageToAdd, ImageUploading, echoToAdd } = storeToRefs(editorStore)
 const settingStore = useSettingStore()
 const { S3Setting } = storeToRefs(settingStore)
+
+// 布局选择（绑定到 editorStore.echoToAdd.layout）
+const layoutOptions = [
+  { label: '瀑布流', value: 'waterfall' },
+  { label: '九宫格', value: 'grid' },
+  { label: '单图轮播', value: 'carousel' },
+  { label: '水平轮播', value: 'horizontal' },
+]
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
当前ech0的图片部分是动态双列网格的布局，即图片数量为双数时是双列网格，单数时最后一张图片占满整行，文字部分置于图片下方，这样就会有以下的几个问题：

1. 在多图展示(超过两张图)或者图片高度不统一的情况下就会显得异常杂乱，又不同于传统瀑布流的布局，每行的高度取决于那一行的最大高度，其中一列会有巨大留白
2. 图片展示在文字内容的上方，在某些以文字为核心的场景下，图片又显得有些喧嚣夺主

基于对各种图文内容分享平台的观察，以图与文的侧重为核心，提供四种布局方案选择可以覆盖图文内容的大部分场景：

- 以文字为核心的场景（文字在上）
<img width="240" height="300" alt="image" src="https://github.com/user-attachments/assets/11f1e489-9743-4041-8b7d-9e2cb222009f" />
<img width="240" height="235" alt="image" src="https://github.com/user-attachments/assets/2347c594-d18c-4f40-a6f5-45eb35e4736e" />

- 以图片为核心的场景（图片在上）
<img width="240" height="350" alt="image" src="https://github.com/user-attachments/assets/562da2b9-147b-4086-b5a0-715304b533ec" />
<img width="240" height="220" alt="image" src="https://github.com/user-attachments/assets/4f1ea0c4-ade2-4544-b634-09e61bd48900" />

- 布局选择页面
<img width="190" height="240" alt="image" src="https://github.com/user-attachments/assets/2329b1f1-5f6c-431c-9838-2f12cb1a7bb8" />

用户可以根据分享的内容选择一种合适的图片布局方式，结合各个平台的特点，以更优雅的方式表达想要表达的内容，满足多样化的需求