### PR TITLE
feat: 重构OAuth2登录流程，重新支持QQ登录

### DIFF
--- a/internal/model/auth/auth.go
+++ b/internal/model/auth/auth.go
@@ -75,11 +75,11 @@ type GoogleUser struct {
 }
 
 // QQTokenResponse QQ token 响应结构
+// OpenID需要通过单独的API调用获取，不在token响应中
 type QQTokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	ExpiresIn    int64  `json:"expires_in"`
 	RefreshToken string `json:"refresh_token"`
-	OpenID       string `json:"openid,omitempty"`
 }
 
 // QQOpenIDResponse QQ OpenID 响应结构
@@ -89,12 +89,15 @@ type QQOpenIDResponse struct {
 }
 
 // QQUser QQ 用户信息
+// Ret和Msg字段用于QQ互联API的错误处理
 type QQUser struct {
-	Nickname     string `json:"nickname"`
-	FigureURL    string `json:"figureurl"`
-	FigureURL1   string `json:"figureurl_1"`
-	FigureURL2   string `json:"figureurl_2"`
-	FigureURLQQ1 string `json:"figureurl_qq_1"`
-	FigureURLQQ2 string `json:"figureurl_qq_2"`
-	Gender       string `json:"gender"`
+	Ret          int    `json:"ret"`            // 返回码，0表示成功
+	Msg          string `json:"msg"`            // 错误信息
+	Nickname     string `json:"nickname"`       // 用户昵称
+	FigureURL    string `json:"figureurl"`      // 30x30头像
+	FigureURL1   string `json:"figureurl_1"`    // 50x50头像
+	FigureURL2   string `json:"figureurl_2"`    // 100x100头像
+	FigureURLQQ1 string `json:"figureurl_qq_1"` // 40x40头像
+	FigureURLQQ2 string `json:"figureurl_qq_2"` // 100x100头像
+	Gender       string `json:"gender"`         // 性别
 }

--- a/internal/model/common/error.go
+++ b/internal/model/common/error.go
@@ -62,6 +62,10 @@ const (
 	NO_PERMISSION_BINDING_GOOGLE   = "没有权限绑定 Google 账号"
 	NO_PERMISSION_BINDING_QQ       = "没有权限绑定 QQ 账号"
 	NO_PERMISSION_BINDING_CUSTOM   = "没有权限绑定自定义 OAuth2 账号"
+	QQ_TOKEN_EXCHANGE_FAILED       = "QQ Token 交换失败"
+	QQ_OPENID_FETCH_FAILED         = "获取 QQ OpenID 失败"
+	QQ_OAUTH_STATE_INVALID         = "QQ OAuth 状态参数无效"
+	QQ_OAUTH_ALREADY_BOUND         = "该 QQ 账号已被其他用户绑定"
 )
 
 // TO DO 错误相关常量

--- a/internal/repository/user/user.go
+++ b/internal/repository/user/user.go
@@ -186,7 +186,17 @@ func (userRepository *UserRepository) BindOAuth(ctx context.Context, userID uint
 	return nil
 }
 
-// GetUserByOAuthID 根据 OAuth 提供商和 OAuth ID 获取用户
+// GetUserByOAuthID 根据OAuth提供商和OAuth ID获取用户
+// 通过查询OAuth绑定表找到对应的用户ID，然后返回完整的用户信息
+//
+// 参数:
+//   - ctx: 上下文对象，用于事务管理
+//   - provider: OAuth提供商名称（如"github", "google", "qq", "custom"）
+//   - oauthID: 第三方平台的用户唯一标识（如GitHub的user ID、QQ的OpenID）
+//
+// 返回:
+//   - model.User: 用户信息
+//   - error: 如果未找到绑定关系或用户不存在，返回错误
 func (userRepository *UserRepository) GetUserByOAuthID(
 	ctx context.Context,
 	provider, oauthID string,

--- a/web/src/views/panel/modules/TheSetting/TheOAuth2Setting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheOAuth2Setting.vue
@@ -282,7 +282,7 @@ const oauth2EditMode = ref(false)
 const OAuth2ProviderOptions = [
   { label: 'GitHub', value: OAuth2Provider.GITHUB },
   { label: 'Google', value: OAuth2Provider.GOOGLE },
-  // { label: 'QQ', value: OAuth2Provider.QQ },
+  { label: 'QQ', value: OAuth2Provider.QQ },
   { label: 'Custom', value: OAuth2Provider.CUSTOM },
 ]
 

--- a/web/src/views/panel/modules/TheSetting/TheUserSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheUserSetting.vue
@@ -21,7 +21,9 @@
           :src="
             !user?.avatar || user?.avatar.length === 0
               ? '/favicon.svg'
-              : `${API_URL}${user?.avatar}`
+              : user.avatar.startsWith('http')
+                ? user.avatar
+                : `${API_URL}${user.avatar}`
           "
           alt="头像"
           class="w-12 h-12 rounded-full ml-2 mr-9 ring-1 ring-gray-200 shadow-sm"


### PR DESCRIPTION
### 优化OAUTH登录流程，使用OAUTH注册自动使用OAUTH的用户名和头像，并重新支持QQ登录，降低普通用户使用门槛
<img width="364" height="205" alt="image" src="https://github.com/user-attachments/assets/aa063645-543b-4219-b19e-b46dde2b0d89" />
<img width="512" height="324" alt="image" src="https://github.com/user-attachments/assets/00462b0e-fe64-4436-a7bb-3497efb1f84c" />

## 相关Issue
resolves #96   QQ登录