### PR TITLE
fix(agent): agent供应商为deepseek时生成近况总结失败

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -128,11 +128,16 @@ func Generate(
 		resp, genErr = cm.Generate(ctx, in)
 
 	case string(commonModel.DeepSeek):
+		var tValue float32 = 1.0
+		if t != nil {
+			tValue = *t
+		}
+
 		cm, err := deepseek.NewChatModel(ctx, &deepseek.ChatModelConfig{
 			APIKey:      apiKey,
 			Model:       model,
 			BaseURL:     baseURL,
-			Temperature: *t,
+			Temperature: tValue,
 		})
 		if err != nil {
 			return "", err


### PR DESCRIPTION
- 问题：agent供应商为deepseek时，配置中Temperature为float32，直接对未初始化的*float32解引用导致空指针报错。
- 解决：供应商为deepseek时提供初始值并对指针判空。