### PR TITLE
feat: add Atom feed discovery link in HTML head

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -18,6 +18,8 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Ech0" />
 
+    <link rel="alternate" type="application/atom+xml" title="Ech0 Atom Feed" href="/rss" />
+
     <!-- Favicon -->
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 


### PR DESCRIPTION
Add <link rel="alternate" type="application/atom+xml" title="Ech0 Atom Feed" href="/rss" /> to <head> for better RSS reader auto-detection.
This pull request adds support for an Atom feed to the website by including a new link in the HTML header.

* Added a `<link rel="alternate">` tag to `web/index.html` to advertise the Atom feed at `/rss`, allowing feed readers to discover and subscribe to updates.