### PR TITLE
修改v3迁移至v4脚本

### DIFF
--- a/internal/migrator/extractor/ech0v3/extractor.go
+++ b/internal/migrator/extractor/ech0v3/extractor.go
@@ -1109,6 +1109,22 @@ func normalizeObjectKeyForV4(objectKey string, pathPrefix string) string {
 	return cleanMigratedFileKey(clean)
 }
 
+// ensureProtocol ensures the URL has a protocol prefix (http:// or https://).
+// If the URL already has a protocol, it returns as-is.
+// If no protocol, it adds https:// or http:// based on useSSL.
+func ensureProtocol(url string, useSSL bool) string {
+	url = strings.TrimSpace(url)
+	lower := strings.ToLower(url)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return url
+	}
+	scheme := "https"
+	if !useSSL {
+		scheme = "http"
+	}
+	return scheme + "://" + url
+}
+
 func buildObjectURLFromSetting(setting settingModel.S3Setting, key string) string {
 	resolvedKey := buildObjectStoragePath(setting, key)
 	if resolvedKey == "" {
@@ -1116,19 +1132,14 @@ func buildObjectURLFromSetting(setting settingModel.S3Setting, key string) strin
 	}
 	cdn := strings.TrimRight(strings.TrimSpace(setting.CDNURL), "/")
 	if cdn != "" {
+		cdn = ensureProtocol(cdn, setting.UseSSL)
 		return cdn + "/" + resolvedKey
 	}
 	endpoint := strings.TrimSpace(setting.Endpoint)
 	if endpoint == "" {
 		return ""
 	}
-	if !strings.HasPrefix(strings.ToLower(endpoint), "http://") && !strings.HasPrefix(strings.ToLower(endpoint), "https://") {
-		scheme := "https"
-		if !setting.UseSSL {
-			scheme = "http"
-		}
-		endpoint = scheme + "://" + endpoint
-	}
+	endpoint = ensureProtocol(endpoint, setting.UseSSL)
 	endpoint = strings.TrimRight(endpoint, "/")
 	bucket := strings.Trim(strings.TrimSpace(setting.BucketName), "/")
 	if bucket == "" {

--- a/internal/migrator/extractor/ech0v3/extractor_perf_test.go
+++ b/internal/migrator/extractor/ech0v3/extractor_perf_test.go
@@ -173,6 +173,68 @@ func TestBuildObjectURLFromSetting(t *testing.T) {
 	}
 }
 
+func TestBuildObjectURLFromSetting_WithCDN(t *testing.T) {
+	// Test CDN with SSL enabled
+	setting := &settingModel.S3Setting{
+		Enable:     true,
+		Endpoint:   "s3.example.com",
+		BucketName: "legacy-bucket",
+		PathPrefix: "upload",
+		UseSSL:     true,
+		CDNURL:     "cdn.example.com",
+	}
+	url := buildObjectURLFromSetting(*setting, "a.png")
+	if url != "https://cdn.example.com/upload/images/a.png" {
+		t.Fatalf("unexpected s3 migrated url with CDN: %s", url)
+	}
+
+	// Test CDN without protocol prefix and SSL disabled
+	setting.UseSSL = false
+	url = buildObjectURLFromSetting(*setting, "a.png")
+	if url != "http://cdn.example.com/upload/images/a.png" {
+		t.Fatalf("unexpected s3 migrated url with CDN and no SSL: %s", url)
+	}
+
+	// Test CDN that already has https:// prefix
+	setting.CDNURL = "https://cdn2.example.com"
+	setting.UseSSL = true
+	url = buildObjectURLFromSetting(*setting, "a.png")
+	if url != "https://cdn2.example.com/upload/images/a.png" {
+		t.Fatalf("unexpected s3 migrated url with CDN already having protocol: %s", url)
+	}
+
+	// Test CDN that already has http:// prefix (should keep http)
+	setting.CDNURL = "http://cdn3.example.com"
+	setting.UseSSL = true
+	url = buildObjectURLFromSetting(*setting, "a.png")
+	if url != "http://cdn3.example.com/upload/images/a.png" {
+		t.Fatalf("unexpected s3 migrated url with CDN having http: %s", url)
+	}
+}
+
+func TestEnsureProtocol(t *testing.T) {
+	tests := []struct {
+		url    string
+		useSSL bool
+		want   string
+	}{
+		{"cdn.example.com", true, "https://cdn.example.com"},
+		{"cdn.example.com", false, "http://cdn.example.com"},
+		{"https://cdn.example.com", true, "https://cdn.example.com"},
+		{"https://cdn.example.com", false, "https://cdn.example.com"},
+		{"http://cdn.example.com", true, "http://cdn.example.com"},
+		{"http://cdn.example.com", false, "http://cdn.example.com"},
+		{"  cdn.example.com  ", true, "https://cdn.example.com"},
+	}
+
+	for _, tt := range tests {
+		got := ensureProtocol(tt.url, tt.useSSL)
+		if got != tt.want {
+			t.Errorf("ensureProtocol(%q, %v) = %q, want %q", tt.url, tt.useSSL, got, tt.want)
+		}
+	}
+}
+
 func TestMapSourceS3SettingToV4_Invalid(t *testing.T) {
 	_, ok := mapSourceS3SettingToV4(&settingModel.S3Setting{
 		Enable:     true,


### PR DESCRIPTION
解决 #185 
1. 修复迁移脚本 (extractor.go)  
  当前s3存储cdn设置可以不带https前缀，迁移时这里的逻辑处理有误。
  添加了 ensureProtocol 函数，确保CDN URL也有正确的协议前缀：
  在 buildObjectURLFromSetting 中（第1117-1119行），CDN情况现在也会添加协议前缀：                                                                                                                                                                                                            

2. 添加测试用例 (extractor_perf_test.go)
  新增2个测试函数，应对cdn设置的不同情况：
    - TestBuildObjectURLFromSetting_WithCDN - 测试CDN场景
    - TestEnsureProtocol - 测试协议添加逻辑