### PR TITLE
feat(auth,comment): add integration comment write API with access token audience checks

### DIFF
--- a/internal/handler/comment/comment.go
+++ b/internal/handler/comment/comment.go
@@ -83,6 +83,25 @@ func (h *CommentHandler) CreateComment() gin.HandlerFunc {
 	})
 }
 
+func (h *CommentHandler) CreateIntegrationComment() gin.HandlerFunc {
+	return res.Execute(func(ctx *gin.Context) res.Response {
+		var dto model.CreateIntegrationCommentDto
+		if err := ctx.ShouldBindJSON(&dto); err != nil {
+			return res.Response{Msg: commonModel.INVALID_REQUEST_BODY, Err: err}
+		}
+		result, err := h.commentService.CreateIntegrationComment(
+			ctx.Request.Context(),
+			ctx.ClientIP(),
+			ctx.Request.UserAgent(),
+			&dto,
+		)
+		if err != nil {
+			return res.Response{Err: err}
+		}
+		return res.Response{Data: result, Msg: commonModel.SUCCESS_MESSAGE}
+	})
+}
+
 func (h *CommentHandler) ListPanelComments() gin.HandlerFunc {
 	return res.Execute(func(ctx *gin.Context) res.Response {
 		query := model.ListCommentQuery{
@@ -201,12 +220,7 @@ func (h *CommentHandler) TestCommentEmail() gin.HandlerFunc {
 
 func (h *CommentHandler) attachOptionalViewer(ctx *gin.Context) {
 	auth := strings.TrimSpace(ctx.GetHeader("Authorization"))
-	userID := service.ParseOptionalUserIDFromAuthHeader(auth)
-	if userID != "" {
-		viewer.AttachToRequest(&ctx.Request, viewer.NewUserViewer(userID))
-		return
-	}
-	viewer.AttachToRequest(&ctx.Request, viewer.NewNoopViewer())
+	viewer.AttachToRequest(&ctx.Request, service.ParseOptionalViewerFromAuthHeader(auth))
 }
 
 func parseQueryInt(ctx *gin.Context, key string, def int) int {

--- a/internal/middleware/scope.go
+++ b/internal/middleware/scope.go
@@ -13,61 +13,77 @@ import (
 
 func RequireScopes(scopes ...string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		v := viewer.MustFromContext(ctx.Request.Context())
-		if v.TokenType() == authModel.TokenTypeSession {
-			ctx.Next()
-			return
-		}
-		if v.TokenType() != authModel.TokenTypeAccess {
-			ctx.JSON(
-				http.StatusUnauthorized,
-				commonModel.FailWithLocalized[any](
-					i18nUtil.Localize(i18nUtil.LocalizerFromGin(ctx), commonModel.MsgKeyAuthTokenInvalid, errUtil.HandleError(&commonModel.ServerError{
-						Msg: commonModel.TOKEN_NOT_VALID,
-						Err: nil,
-					}), nil),
-					commonModel.ErrCodeTokenInvalid,
-					commonModel.MsgKeyAuthTokenInvalid,
-					nil,
-				),
-			)
-			ctx.Abort()
-			return
-		}
-		if !containsValidAudience(v.Audience()) {
-			ctx.JSON(
-				http.StatusForbidden,
-				commonModel.FailWithLocalized[any](
-					i18nUtil.Localize(i18nUtil.LocalizerFromGin(ctx), commonModel.MsgKeyAuthAudienceForbidden, errUtil.HandleError(&commonModel.ServerError{
-						Msg: commonModel.NO_PERMISSION_DENIED,
-						Err: nil,
-					}), nil),
-					commonModel.ErrCodeAudienceForbidden,
-					commonModel.MsgKeyAuthAudienceForbidden,
-					nil,
-				),
-			)
-			ctx.Abort()
-			return
-		}
-		if !containsAllScopes(v.Scopes(), scopes) {
-			ctx.JSON(
-				http.StatusForbidden,
-				commonModel.FailWithLocalized[any](
-					i18nUtil.Localize(i18nUtil.LocalizerFromGin(ctx), commonModel.MsgKeyAuthScopeForbidden, errUtil.HandleError(&commonModel.ServerError{
-						Msg: commonModel.NO_PERMISSION_DENIED,
-						Err: nil,
-					}), nil),
-					commonModel.ErrCodeScopeForbidden,
-					commonModel.MsgKeyAuthScopeForbidden,
-					nil,
-				),
-			)
-			ctx.Abort()
-			return
-		}
-		ctx.Next()
+		enforceScopes(ctx, true, "", scopes...)
 	}
+}
+
+func RequireAccessTokenScopes(scopes ...string) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		enforceScopes(ctx, false, "", scopes...)
+	}
+}
+
+func RequireAccessTokenAudienceScopes(audience string, scopes ...string) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		enforceScopes(ctx, false, audience, scopes...)
+	}
+}
+
+func enforceScopes(ctx *gin.Context, allowSession bool, requiredAudience string, scopes ...string) {
+	v := viewer.MustFromContext(ctx.Request.Context())
+	if allowSession && v.TokenType() == authModel.TokenTypeSession {
+		ctx.Next()
+		return
+	}
+	if v.TokenType() != authModel.TokenTypeAccess {
+		ctx.JSON(
+			http.StatusUnauthorized,
+			commonModel.FailWithLocalized[any](
+				i18nUtil.Localize(i18nUtil.LocalizerFromGin(ctx), commonModel.MsgKeyAuthTokenInvalid, errUtil.HandleError(&commonModel.ServerError{
+					Msg: commonModel.TOKEN_NOT_VALID,
+					Err: nil,
+				}), nil),
+				commonModel.ErrCodeTokenInvalid,
+				commonModel.MsgKeyAuthTokenInvalid,
+				nil,
+			),
+		)
+		ctx.Abort()
+		return
+	}
+	if !containsRequiredAudience(v.Audience(), requiredAudience) {
+		ctx.JSON(
+			http.StatusForbidden,
+			commonModel.FailWithLocalized[any](
+				i18nUtil.Localize(i18nUtil.LocalizerFromGin(ctx), commonModel.MsgKeyAuthAudienceForbidden, errUtil.HandleError(&commonModel.ServerError{
+					Msg: commonModel.NO_PERMISSION_DENIED,
+					Err: nil,
+				}), nil),
+				commonModel.ErrCodeAudienceForbidden,
+				commonModel.MsgKeyAuthAudienceForbidden,
+				nil,
+			),
+		)
+		ctx.Abort()
+		return
+	}
+	if !containsAllScopes(v.Scopes(), scopes) {
+		ctx.JSON(
+			http.StatusForbidden,
+			commonModel.FailWithLocalized[any](
+				i18nUtil.Localize(i18nUtil.LocalizerFromGin(ctx), commonModel.MsgKeyAuthScopeForbidden, errUtil.HandleError(&commonModel.ServerError{
+					Msg: commonModel.NO_PERMISSION_DENIED,
+					Err: nil,
+				}), nil),
+				commonModel.ErrCodeScopeForbidden,
+				commonModel.MsgKeyAuthScopeForbidden,
+				nil,
+			),
+		)
+		ctx.Abort()
+		return
+	}
+	ctx.Next()
 }
 
 func containsValidAudience(audiences []string) bool {
@@ -76,6 +92,18 @@ func containsValidAudience(audiences []string) bool {
 	}
 	for _, audience := range audiences {
 		if authModel.IsValidAudience(audience) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsRequiredAudience(audiences []string, requiredAudience string) bool {
+	if requiredAudience == "" {
+		return containsValidAudience(audiences)
+	}
+	for _, audience := range audiences {
+		if audience == requiredAudience {
 			return true
 		}
 	}

--- a/internal/middleware/scope_test.go
+++ b/internal/middleware/scope_test.go
@@ -74,6 +74,132 @@ func TestRequireScopes_ReturnsAudienceForbiddenCode(t *testing.T) {
 	}
 }
 
+func TestRequireAccessTokenScopes_RejectsSessionToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		viewer.AttachToRequest(
+			&c.Request,
+			viewer.NewUserViewerWithToken(
+				"user-1",
+				authModel.TokenTypeSession,
+				nil,
+				nil,
+				"",
+			),
+		)
+		c.Next()
+	})
+	r.POST("/protected", RequireAccessTokenScopes(authModel.ScopeCommentWrite), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/protected", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+	if got := parseErrorCode(rec.Body.Bytes()); got != commonModel.ErrCodeTokenInvalid {
+		t.Fatalf("expected error code %s, got %s", commonModel.ErrCodeTokenInvalid, got)
+	}
+}
+
+func TestRequireAccessTokenScopes_AllowsScopedAccessToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		viewer.AttachToRequest(
+			&c.Request,
+			viewer.NewUserViewerWithToken(
+				"user-1",
+				authModel.TokenTypeAccess,
+				[]string{authModel.ScopeCommentWrite},
+				[]string{authModel.AudienceIntegration},
+				"jti-comment-write",
+			),
+		)
+		c.Next()
+	})
+	r.POST("/protected", RequireAccessTokenScopes(authModel.ScopeCommentWrite), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/protected", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
+func TestRequireAccessTokenAudienceScopes_RejectsWrongAudience(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		viewer.AttachToRequest(
+			&c.Request,
+			viewer.NewUserViewerWithToken(
+				"user-1",
+				authModel.TokenTypeAccess,
+				[]string{authModel.ScopeCommentWrite},
+				[]string{authModel.AudiencePublic},
+				"jti-comment-write-public",
+			),
+		)
+		c.Next()
+	})
+	r.POST(
+		"/protected",
+		RequireAccessTokenAudienceScopes(authModel.AudienceIntegration, authModel.ScopeCommentWrite),
+		func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/protected", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+	}
+	if got := parseErrorCode(rec.Body.Bytes()); got != commonModel.ErrCodeAudienceForbidden {
+		t.Fatalf("expected error code %s, got %s", commonModel.ErrCodeAudienceForbidden, got)
+	}
+}
+
+func TestRequireAccessTokenAudienceScopes_AllowsMatchingAudience(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		viewer.AttachToRequest(
+			&c.Request,
+			viewer.NewUserViewerWithToken(
+				"user-1",
+				authModel.TokenTypeAccess,
+				[]string{authModel.ScopeCommentWrite},
+				[]string{authModel.AudienceIntegration},
+				"jti-comment-write-integration",
+			),
+		)
+		c.Next()
+	})
+	r.POST(
+		"/protected",
+		RequireAccessTokenAudienceScopes(authModel.AudienceIntegration, authModel.ScopeCommentWrite),
+		func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/protected", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+	}
+}
+
 func parseErrorCode(body []byte) string {
 	var payload struct {
 		ErrorCode string `json:"error_code"`

--- a/internal/model/comment/comment.go
+++ b/internal/model/comment/comment.go
@@ -61,6 +61,14 @@ type CreateCommentDto struct {
 	CaptchaToken  string `json:"captcha_token"`
 }
 
+type CreateIntegrationCommentDto struct {
+	EchoID   string `json:"echo_id" binding:"required"`
+	Nickname string `json:"nickname" binding:"required"`
+	Email    string `json:"email" binding:"required"`
+	Website  string `json:"website"`
+	Content  string `json:"content" binding:"required"`
+}
+
 type CreateCommentResult struct {
 	ID     string `json:"id"`
 	Status Status `json:"status"`

--- a/internal/router/comment.go
+++ b/internal/router/comment.go
@@ -5,6 +5,7 @@ import (
 	"github.com/lin-snow/ech0/internal/captcha"
 	"github.com/lin-snow/ech0/internal/handler"
 	"github.com/lin-snow/ech0/internal/middleware"
+	authModel "github.com/lin-snow/ech0/internal/model/auth"
 )
 
 func setupCommentRoutes(appRouterGroup *AppRouterGroup, h *handler.Bundle) {
@@ -23,15 +24,59 @@ func setupCommentRoutes(appRouterGroup *AppRouterGroup, h *handler.Bundle) {
 		h.CommentHandler.ListPublicComments(),
 	)
 	appRouterGroup.PublicRouterGroup.POST("/comments", h.CommentHandler.CreateComment())
+	appRouterGroup.AuthRouterGroup.POST(
+		"/comments/integration",
+		middleware.RequireAccessTokenAudienceScopes(
+			authModel.AudienceIntegration,
+			authModel.ScopeCommentWrite,
+		),
+		h.CommentHandler.CreateIntegrationComment(),
+	)
 
 	// Admin Panel
-	appRouterGroup.AuthRouterGroup.GET("/panel/comments", h.CommentHandler.ListPanelComments())
-	appRouterGroup.AuthRouterGroup.GET("/panel/comments/:id", h.CommentHandler.GetCommentByID())
-	appRouterGroup.AuthRouterGroup.PATCH("/panel/comments/:id/status", h.CommentHandler.UpdateCommentStatus())
-	appRouterGroup.AuthRouterGroup.PATCH("/panel/comments/:id/hot", h.CommentHandler.UpdateCommentHot())
-	appRouterGroup.AuthRouterGroup.DELETE("/panel/comments/:id", h.CommentHandler.DeleteComment())
-	appRouterGroup.AuthRouterGroup.POST("/panel/comments/batch", h.CommentHandler.BatchAction())
-	appRouterGroup.AuthRouterGroup.GET("/panel/comments/settings", h.CommentHandler.GetCommentSetting())
-	appRouterGroup.AuthRouterGroup.PUT("/panel/comments/settings", h.CommentHandler.UpdateCommentSetting())
-	appRouterGroup.AuthRouterGroup.POST("/panel/comments/settings/test-email", h.CommentHandler.TestCommentEmail())
+	appRouterGroup.AuthRouterGroup.GET(
+		"/panel/comments",
+		middleware.RequireScopes(authModel.ScopeCommentRead),
+		h.CommentHandler.ListPanelComments(),
+	)
+	appRouterGroup.AuthRouterGroup.GET(
+		"/panel/comments/:id",
+		middleware.RequireScopes(authModel.ScopeCommentRead),
+		h.CommentHandler.GetCommentByID(),
+	)
+	appRouterGroup.AuthRouterGroup.PATCH(
+		"/panel/comments/:id/status",
+		middleware.RequireScopes(authModel.ScopeCommentMod),
+		h.CommentHandler.UpdateCommentStatus(),
+	)
+	appRouterGroup.AuthRouterGroup.PATCH(
+		"/panel/comments/:id/hot",
+		middleware.RequireScopes(authModel.ScopeCommentMod),
+		h.CommentHandler.UpdateCommentHot(),
+	)
+	appRouterGroup.AuthRouterGroup.DELETE(
+		"/panel/comments/:id",
+		middleware.RequireScopes(authModel.ScopeCommentMod),
+		h.CommentHandler.DeleteComment(),
+	)
+	appRouterGroup.AuthRouterGroup.POST(
+		"/panel/comments/batch",
+		middleware.RequireScopes(authModel.ScopeCommentMod),
+		h.CommentHandler.BatchAction(),
+	)
+	appRouterGroup.AuthRouterGroup.GET(
+		"/panel/comments/settings",
+		middleware.RequireScopes(authModel.ScopeAdminSettings),
+		h.CommentHandler.GetCommentSetting(),
+	)
+	appRouterGroup.AuthRouterGroup.PUT(
+		"/panel/comments/settings",
+		middleware.RequireScopes(authModel.ScopeAdminSettings),
+		h.CommentHandler.UpdateCommentSetting(),
+	)
+	appRouterGroup.AuthRouterGroup.POST(
+		"/panel/comments/settings/test-email",
+		middleware.RequireScopes(authModel.ScopeAdminSettings),
+		h.CommentHandler.TestCommentEmail(),
+	)
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -44,6 +44,7 @@ func TestSetupRouter_RegistersKeyRoutes(t *testing.T) {
 		{method: http.MethodGet, path: "/swagger/*any"},
 		{method: http.MethodPost, path: "/api/login"},
 		{method: http.MethodPost, path: "/api/echo"},
+		{method: http.MethodPost, path: "/api/comments/integration"},
 		{method: http.MethodGet, path: "/api/init/status"},
 		{method: http.MethodGet, path: "/api/settings"},
 		{method: http.MethodGet, path: "/api/agent/recent"},

--- a/internal/service/comment/comment.go
+++ b/internal/service/comment/comment.go
@@ -20,6 +20,7 @@ import (
 	captchaCfg "github.com/lin-snow/ech0/internal/captcha"
 	"github.com/lin-snow/ech0/internal/config"
 	contracts "github.com/lin-snow/ech0/internal/event/contracts"
+	authModel "github.com/lin-snow/ech0/internal/model/auth"
 	model "github.com/lin-snow/ech0/internal/model/comment"
 	commonModel "github.com/lin-snow/ech0/internal/model/common"
 	userModel "github.com/lin-snow/ech0/internal/model/user"
@@ -115,24 +116,12 @@ func (s *CommentService) CreateComment(
 		return model.CreateCommentResult{}, err
 	}
 
-	comment := model.Comment{
-		EchoID:    strings.TrimSpace(dto.EchoID),
-		Content:   strings.TrimSpace(dto.Content),
-		IPHash:    hashClientIP(clientIP),
-		UserAgent: strings.TrimSpace(userAgent),
-		Status:    model.StatusPending,
-		Source:    model.SourceGuest,
-	}
-	if comment.EchoID == "" || comment.Content == "" {
-		return model.CreateCommentResult{},
-			commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "评论内容不能为空")
-	}
-	if utf8.RuneCountInString(comment.Content) > maxCommentRunes {
-		return model.CreateCommentResult{},
-			commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "评论内容不能超过200字")
+	comment, err := newCommentFromInput(clientIP, userAgent, dto.EchoID, dto.Content)
+	if err != nil {
+		return model.CreateCommentResult{}, err
 	}
 
-	if validUser && (user.IsAdmin || user.IsOwner) {
+	if validUser && canUsePrivilegedCommentIdentity(ctx, user) {
 		comment.Source = model.SourceSystem
 		comment.Nickname = user.Username
 		// 内部成员评论允许邮箱为空，不再自动填充占位邮箱。
@@ -140,63 +129,49 @@ func (s *CommentService) CreateComment(
 		comment.UserID = &user.ID
 		comment.Status = model.StatusApproved
 	} else {
-		nickname := strings.TrimSpace(dto.Nickname)
-		email := strings.TrimSpace(dto.Email)
-		website := strings.TrimSpace(dto.Website)
-		if nickname == "" || email == "" {
-			return model.CreateCommentResult{},
-				commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "昵称和邮箱不能为空")
+		if err := populateExternalCommentFields(&comment, dto.Nickname, dto.Email, dto.Website); err != nil {
+			return model.CreateCommentResult{}, err
 		}
-		if _, err := mail.ParseAddress(email); err != nil {
-			return model.CreateCommentResult{},
-				commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "邮箱格式无效")
-		}
-		if website != "" {
-			parsed, err := url.ParseRequestURI(website)
-			if err != nil || parsed.Scheme == "" || parsed.Host == "" {
-				return model.CreateCommentResult{},
-					commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "网址格式无效")
-			}
-		}
-		comment.Nickname = nickname
-		comment.Email = email
-		comment.Website = website
 
 		if !setting.RequireApproval {
 			comment.Status = model.StatusApproved
 		}
 
-		if err := s.checkRateLimit(ctx, comment.IPHash, email, ""); err != nil {
+		if err := s.checkRateLimit(ctx, comment.IPHash, comment.Email, ""); err != nil {
 			return model.CreateCommentResult{}, err
 		}
 	}
 
-	duplicated, err := s.repo.ExistsRecentDuplicate(
-		ctx,
-		comment.EchoID,
-		comment.Content,
-		comment.Email,
-		comment.IPHash,
-		derefString(comment.UserID),
-		recentDuplicateSec,
-	)
+	return s.persistCreatedComment(ctx, &comment)
+}
+
+func (s *CommentService) CreateIntegrationComment(
+	ctx context.Context,
+	clientIP string,
+	userAgent string,
+	dto *model.CreateIntegrationCommentDto,
+) (model.CreateCommentResult, error) {
+	setting, err := s.GetSystemSetting(ctx)
 	if err != nil {
 		return model.CreateCommentResult{}, err
 	}
-	if duplicated {
+	if !setting.EnableComment {
 		return model.CreateCommentResult{},
-			commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "请勿重复提交相同评论")
+			commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "评论功能未启用")
 	}
 
-	if err := s.repo.CreateComment(ctx, &comment); err != nil {
+	comment, err := newCommentFromInput(clientIP, userAgent, dto.EchoID, dto.Content)
+	if err != nil {
 		return model.CreateCommentResult{}, err
 	}
-	s.emitCommentCreated(ctx, comment)
-	s.notifyOwnerAsync(ctx, "created", comment)
-	return model.CreateCommentResult{
-		ID:     comment.ID,
-		Status: comment.Status,
-	}, nil
+	if err := populateExternalCommentFields(&comment, dto.Nickname, dto.Email, dto.Website); err != nil {
+		return model.CreateCommentResult{}, err
+	}
+	if !setting.RequireApproval {
+		comment.Status = model.StatusApproved
+	}
+
+	return s.persistCreatedComment(ctx, &comment)
 }
 
 func (s *CommentService) ListPublicByEchoID(ctx context.Context, echoID string) ([]model.Comment, error) {
@@ -743,16 +718,22 @@ func (s *CommentService) resolveRequestUser(ctx context.Context) (user userModel
 	return u, true, nil
 }
 
-func ParseOptionalUserIDFromAuthHeader(authHeader string) string {
+func ParseOptionalViewerFromAuthHeader(authHeader string) viewer.Context {
 	parts := strings.SplitN(strings.TrimSpace(authHeader), " ", 2)
 	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-		return ""
+		return viewer.NewNoopViewer()
 	}
 	claims, err := jwtUtil.ParseToken(strings.TrimSpace(parts[1]))
 	if err != nil {
-		return ""
+		return viewer.NewNoopViewer()
 	}
-	return claims.Userid
+	return viewer.NewUserViewerWithToken(
+		claims.Userid,
+		claims.Type,
+		claims.Scopes,
+		[]string(claims.Audience),
+		claims.ID,
+	)
 }
 
 func hashClientIP(ip string) string {
@@ -776,4 +757,90 @@ func buildDiceBearURL(seed string) string {
 		trimmed = "guest"
 	}
 	return "https://api.dicebear.com/9.x/fun-emoji/svg?seed=" + url.QueryEscape(trimmed)
+}
+
+func newCommentFromInput(clientIP, userAgent, echoID, content string) (model.Comment, error) {
+	comment := model.Comment{
+		EchoID:    strings.TrimSpace(echoID),
+		Content:   strings.TrimSpace(content),
+		IPHash:    hashClientIP(clientIP),
+		UserAgent: strings.TrimSpace(userAgent),
+		Status:    model.StatusPending,
+		Source:    model.SourceGuest,
+	}
+	if comment.EchoID == "" || comment.Content == "" {
+		return model.Comment{},
+			commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "评论内容不能为空")
+	}
+	if utf8.RuneCountInString(comment.Content) > maxCommentRunes {
+		return model.Comment{},
+			commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "评论内容不能超过200字")
+	}
+	return comment, nil
+}
+
+func populateExternalCommentFields(comment *model.Comment, nickname, email, website string) error {
+	nickname = strings.TrimSpace(nickname)
+	email = strings.TrimSpace(email)
+	website = strings.TrimSpace(website)
+	if nickname == "" || email == "" {
+		return commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "昵称和邮箱不能为空")
+	}
+	if _, err := mail.ParseAddress(email); err != nil {
+		return commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "邮箱格式无效")
+	}
+	if website != "" {
+		parsed, err := url.ParseRequestURI(website)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			return commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "网址格式无效")
+		}
+	}
+	comment.Nickname = nickname
+	comment.Email = email
+	comment.Website = website
+	return nil
+}
+
+func (s *CommentService) persistCreatedComment(
+	ctx context.Context,
+	comment *model.Comment,
+) (model.CreateCommentResult, error) {
+	duplicated, err := s.repo.ExistsRecentDuplicate(
+		ctx,
+		comment.EchoID,
+		comment.Content,
+		comment.Email,
+		comment.IPHash,
+		derefString(comment.UserID),
+		recentDuplicateSec,
+	)
+	if err != nil {
+		return model.CreateCommentResult{}, err
+	}
+	if duplicated {
+		return model.CreateCommentResult{},
+			commonModel.NewBizError(commonModel.ErrCodeInvalidRequest, "请勿重复提交相同评论")
+	}
+
+	if err := s.repo.CreateComment(ctx, comment); err != nil {
+		return model.CreateCommentResult{}, err
+	}
+	s.emitCommentCreated(ctx, *comment)
+	s.notifyOwnerAsync(ctx, "created", *comment)
+	return model.CreateCommentResult{
+		ID:     comment.ID,
+		Status: comment.Status,
+	}, nil
+}
+
+func canUsePrivilegedCommentIdentity(ctx context.Context, user userModel.User) bool {
+	if !user.IsAdmin && !user.IsOwner {
+		return false
+	}
+	v := viewer.MustFromContext(ctx)
+	if v == nil {
+		return false
+	}
+	tokenType := strings.TrimSpace(v.TokenType())
+	return tokenType == "" || tokenType == authModel.TokenTypeSession
 }

--- a/internal/service/comment/comment_create_test.go
+++ b/internal/service/comment/comment_create_test.go
@@ -1,0 +1,249 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	authModel "github.com/lin-snow/ech0/internal/model/auth"
+	model "github.com/lin-snow/ech0/internal/model/comment"
+	userModel "github.com/lin-snow/ech0/internal/model/user"
+	jwtUtil "github.com/lin-snow/ech0/internal/util/jwt"
+	"github.com/lin-snow/ech0/pkg/viewer"
+)
+
+func TestCreateIntegrationComment_RespectsApprovalSetting(t *testing.T) {
+	tests := []struct {
+		name            string
+		requireApproval bool
+		wantStatus      model.Status
+	}{
+		{
+			name:            "approval enabled keeps comment pending",
+			requireApproval: true,
+			wantStatus:      model.StatusPending,
+		},
+		{
+			name:            "approval disabled auto approves comment",
+			requireApproval: false,
+			wantStatus:      model.StatusApproved,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &stubCommentRepository{}
+			service := NewCommentService(
+				nil,
+				repo,
+				stubCommentKeyValueRepository{
+					raw: `{"enable_comment":true,"require_approval":` + boolString(tc.requireApproval) + `,"captcha_enabled":false}`,
+				},
+				nil,
+				nil,
+			)
+
+			result, err := service.CreateIntegrationComment(
+				context.Background(),
+				"127.0.0.1",
+				"test-agent",
+				&model.CreateIntegrationCommentDto{
+					EchoID:   "echo-1",
+					Nickname: "Alice",
+					Email:    "alice@example.com",
+					Website:  "https://example.com",
+					Content:  "hello from integration",
+				},
+			)
+			if err != nil {
+				t.Fatalf("create integration comment failed: %v", err)
+			}
+			if result.Status != tc.wantStatus {
+				t.Fatalf("expected status %s, got %s", tc.wantStatus, result.Status)
+			}
+			if repo.created == nil {
+				t.Fatal("expected comment to be created")
+			}
+			if repo.created.Source != model.SourceGuest {
+				t.Fatalf("expected source %s, got %s", model.SourceGuest, repo.created.Source)
+			}
+			if repo.created.UserID != nil {
+				t.Fatalf("expected integration comment user_id to be nil, got %v", *repo.created.UserID)
+			}
+		})
+	}
+}
+
+func TestCanUsePrivilegedCommentIdentity_OnlySessionOrLegacyViewerAllowed(t *testing.T) {
+	admin := userModel.User{ID: "admin-1", IsAdmin: true}
+
+	if !canUsePrivilegedCommentIdentity(
+		viewer.WithContext(context.Background(), viewer.NewUserViewerWithToken(
+			admin.ID,
+			authModel.TokenTypeSession,
+			nil,
+			nil,
+			"",
+		)),
+		admin,
+	) {
+		t.Fatal("expected session viewer to retain privileged comment identity")
+	}
+
+	if canUsePrivilegedCommentIdentity(
+		viewer.WithContext(context.Background(), viewer.NewUserViewerWithToken(
+			admin.ID,
+			authModel.TokenTypeAccess,
+			[]string{authModel.ScopeCommentWrite},
+			[]string{authModel.AudienceIntegration},
+			"jti-integration",
+		)),
+		admin,
+	) {
+		t.Fatal("expected access token viewer to be treated as non-system comment")
+	}
+
+	if !canUsePrivilegedCommentIdentity(
+		viewer.WithContext(context.Background(), viewer.NewUserViewer(admin.ID)),
+		admin,
+	) {
+		t.Fatal("expected legacy viewer without token metadata to retain compatibility")
+	}
+}
+
+func TestParseOptionalViewerFromAuthHeader_PreservesTokenMetadata(t *testing.T) {
+	user := userModel.User{ID: "user-1", Username: "alice"}
+	token, err := jwtUtil.GenerateToken(
+		jwtUtil.CreateAccessClaimsWithExpiry(
+			user,
+			int64(time.Hour.Seconds()),
+			[]string{authModel.ScopeCommentWrite},
+			authModel.AudienceIntegration,
+			"jti-comment-write",
+		),
+	)
+	if err != nil {
+		t.Fatalf("generate token failed: %v", err)
+	}
+
+	v := ParseOptionalViewerFromAuthHeader("Bearer " + token)
+	if v.UserID() != user.ID {
+		t.Fatalf("expected user id %s, got %s", user.ID, v.UserID())
+	}
+	if v.TokenType() != authModel.TokenTypeAccess {
+		t.Fatalf("expected token type %s, got %s", authModel.TokenTypeAccess, v.TokenType())
+	}
+	if len(v.Scopes()) != 1 || v.Scopes()[0] != authModel.ScopeCommentWrite {
+		t.Fatalf("expected comment:write scope, got %v", v.Scopes())
+	}
+	if len(v.Audience()) != 1 || v.Audience()[0] != authModel.AudienceIntegration {
+		t.Fatalf("expected integration audience, got %v", v.Audience())
+	}
+	if v.TokenID() != "jti-comment-write" {
+		t.Fatalf("expected token id jti-comment-write, got %s", v.TokenID())
+	}
+}
+
+type stubCommentRepository struct {
+	created *model.Comment
+}
+
+func (r *stubCommentRepository) CreateComment(_ context.Context, c *model.Comment) error {
+	clone := *c
+	if clone.ID == "" {
+		clone.ID = "comment-1"
+		c.ID = clone.ID
+	}
+	r.created = &clone
+	return nil
+}
+
+func (r *stubCommentRepository) ListPublicByEchoID(context.Context, string) ([]model.Comment, error) {
+	return nil, nil
+}
+
+func (r *stubCommentRepository) ListPublicComments(context.Context, int) ([]model.Comment, error) {
+	return nil, nil
+}
+
+func (r *stubCommentRepository) ListComments(context.Context, model.ListCommentQuery) (model.PageResult[model.Comment], error) {
+	return model.PageResult[model.Comment]{}, nil
+}
+
+func (r *stubCommentRepository) GetCommentByID(context.Context, string) (model.Comment, error) {
+	return model.Comment{}, nil
+}
+
+func (r *stubCommentRepository) UpdateCommentStatus(context.Context, string, model.Status) error {
+	return nil
+}
+
+func (r *stubCommentRepository) UpdateCommentHot(context.Context, string, bool) error {
+	return nil
+}
+
+func (r *stubCommentRepository) DeleteComment(context.Context, string) error {
+	return nil
+}
+
+func (r *stubCommentRepository) BatchUpdateStatus(context.Context, []string, model.Status) error {
+	return nil
+}
+
+func (r *stubCommentRepository) BatchDelete(context.Context, []string) error {
+	return nil
+}
+
+func (r *stubCommentRepository) CountByIPWithin(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
+func (r *stubCommentRepository) CountByEmailWithin(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
+func (r *stubCommentRepository) CountByUserWithin(context.Context, string, int64) (int64, error) {
+	return 0, nil
+}
+
+func (r *stubCommentRepository) ExistsRecentDuplicate(
+	context.Context,
+	string,
+	string,
+	string,
+	string,
+	string,
+	int64,
+) (bool, error) {
+	return false, nil
+}
+
+type stubCommentKeyValueRepository struct {
+	raw string
+}
+
+func (r stubCommentKeyValueRepository) GetKeyValue(_ context.Context, key string) (string, error) {
+	if key != model.CommentSystemSettingKey {
+		return "", errors.New("not found")
+	}
+	return r.raw, nil
+}
+
+func (r stubCommentKeyValueRepository) AddKeyValue(context.Context, string, string) error {
+	return nil
+}
+
+func (r stubCommentKeyValueRepository) AddOrUpdateKeyValue(context.Context, string, string) error {
+	return nil
+}
+
+func boolString(v bool) string {
+	if v {
+		return "true"
+	}
+	return "false"
+}
+
+var _ Repository = (*stubCommentRepository)(nil)
+var _ KeyValueRepository = (*stubCommentKeyValueRepository)(nil)

--- a/internal/service/comment/ports.go
+++ b/internal/service/comment/ports.go
@@ -17,6 +17,12 @@ type Service interface {
 		userAgent string,
 		dto *model.CreateCommentDto,
 	) (model.CreateCommentResult, error)
+	CreateIntegrationComment(
+		ctx context.Context,
+		clientIP,
+		userAgent string,
+		dto *model.CreateIntegrationCommentDto,
+	) (model.CreateCommentResult, error)
 	ListPublicByEchoID(ctx context.Context, echoID string) ([]model.Comment, error)
 	ListPublicComments(ctx context.Context, limit int) ([]model.Comment, error)
 	ListPanelComments(ctx context.Context, query model.ListCommentQuery) (model.PageResult[model.Comment], error)

--- a/internal/service/setting/access_token_service.go
+++ b/internal/service/setting/access_token_service.go
@@ -150,10 +150,22 @@ func validateAccessTokenRequest(user userModel.User, dto *model.AccessTokenSetti
 			return errors.New(commonModel.INVALID_PARAMS_BODY)
 		}
 	}
+	if requiresIntegrationAudience(dto.Scopes) && dto.Audience != authModel.AudienceIntegration {
+		return errors.New(commonModel.INVALID_PARAMS_BODY)
+	}
 	if authModel.HasAdminScope(dto.Scopes) && !user.IsAdmin {
 		return errors.New(commonModel.NO_PERMISSION_DENIED)
 	}
 	return nil
+}
+
+func requiresIntegrationAudience(scopes []string) bool {
+	for _, scope := range scopes {
+		if scope == authModel.ScopeCommentWrite {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeScopes(scopes []string) []string {

--- a/internal/service/setting/access_token_service_test.go
+++ b/internal/service/setting/access_token_service_test.go
@@ -46,3 +46,29 @@ func TestCreateAccessToken_RejectsAdminScopeForNonAdminUser(t *testing.T) {
 		t.Fatal("expected error for admin scope on non-admin user")
 	}
 }
+
+func TestCreateAccessToken_RejectsCommentWriteWithoutIntegrationAudience(t *testing.T) {
+	user := userModel.User{IsAdmin: true}
+	dto := &model.AccessTokenSettingDto{
+		Name:     "bad-comment-audience",
+		Expiry:   model.EIGHT_HOUR_EXPIRY,
+		Scopes:   []string{authModel.ScopeCommentWrite},
+		Audience: authModel.AudiencePublic,
+	}
+	if err := validateAccessTokenRequest(user, dto); err == nil {
+		t.Fatal("expected error for comment:write without integration audience")
+	}
+}
+
+func TestCreateAccessToken_AllowsCommentWriteWithIntegrationAudience(t *testing.T) {
+	user := userModel.User{IsAdmin: true}
+	dto := &model.AccessTokenSettingDto{
+		Name:     "comment-integration",
+		Expiry:   model.EIGHT_HOUR_EXPIRY,
+		Scopes:   []string{authModel.ScopeCommentWrite},
+		Audience: authModel.AudienceIntegration,
+	}
+	if err := validateAccessTokenRequest(user, dto); err != nil {
+		t.Fatalf("expected integration audience to pass, got %v", err)
+	}
+}

--- a/web/src/locales/messages/de-DE.json
+++ b/web/src/locales/messages/de-DE.json
@@ -740,6 +740,8 @@
     "scopeCommentRead": "Kommentare lesen",
     "scopeCommentWrite": "Kommentare schreiben",
     "scopeCommentModerate": "Kommentare moderieren",
+    "commentWriteAudienceHint": "„Kommentare schreiben“ erfordert die Audience „Integration“.",
+    "commentWriteAudienceRequired": "„Kommentare schreiben“ erfordert die Audience „Integration“",
     "scopeFileRead": "Dateien lesen",
     "scopeFileWrite": "Dateien hochladen/verwalten",
     "scopeProfileRead": "Profil lesen",

--- a/web/src/locales/messages/en-US.json
+++ b/web/src/locales/messages/en-US.json
@@ -740,6 +740,8 @@
     "scopeCommentRead": "Read comments",
     "scopeCommentWrite": "Write comments",
     "scopeCommentModerate": "Moderate comments",
+    "commentWriteAudienceHint": "\"Write comments\" requires the \"Integration\" audience.",
+    "commentWriteAudienceRequired": "\"Write comments\" requires the \"Integration\" audience",
     "scopeFileRead": "Read files",
     "scopeFileWrite": "Upload/Manage files",
     "scopeProfileRead": "Read profile",

--- a/web/src/locales/messages/zh-CN.json
+++ b/web/src/locales/messages/zh-CN.json
@@ -740,6 +740,8 @@
     "scopeCommentRead": "查看评论",
     "scopeCommentWrite": "发表评论",
     "scopeCommentModerate": "评论审核",
+    "commentWriteAudienceHint": "“发表评论”需搭配“系统集成”受众。",
+    "commentWriteAudienceRequired": "发表评论权限要求受众为“系统集成”",
     "scopeFileRead": "查看文件",
     "scopeFileWrite": "上传/管理文件",
     "scopeProfileRead": "查看个人资料",

--- a/web/src/views/panel/modules/TheSetting/TheAccessTokenSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheAccessTokenSetting.vue
@@ -133,6 +133,9 @@
               class="w-full h-9 bg-[var(--color-bg-surface)]! bg-op-80"
               :placeholder="t('accessTokenSetting.audiencePlaceholder')"
             />
+            <span v-if="audienceError" class="text-xs text-[var(--color-danger)]">{{
+              audienceError
+            }}</span>
           </div>
         </div>
 
@@ -142,6 +145,12 @@
           >
           <p class="text-xs text-[var(--color-text-muted)]">
             {{ t('accessTokenSetting.scopesHint') }}
+          </p>
+          <p
+            v-if="requiresIntegrationAudience"
+            class="text-xs text-[var(--color-text-muted)]"
+          >
+            {{ t('accessTokenSetting.commentWriteAudienceHint') }}
           </p>
           <div
             v-for="group in scopeGroups"
@@ -370,6 +379,7 @@ const accessTokenToAdd = ref<App.Api.Setting.AccessTokenDto>({
 })
 const nameError = ref('')
 const scopesError = ref('')
+const audienceError = ref('')
 
 const isSubmitting = ref<boolean>(false)
 const scopeLabelMap: Record<string, string> = {
@@ -432,6 +442,10 @@ function hasScope(scope: string) {
   return accessTokenToAdd.value.scopes.includes(scope)
 }
 
+const requiresIntegrationAudience = computed(() =>
+  accessTokenToAdd.value.scopes.includes('comment:write'),
+)
+
 function toggleScope(scope: string) {
   const scopes = accessTokenToAdd.value.scopes
   if (scopes.includes(scope)) {
@@ -450,11 +464,13 @@ function resetAccessTokenForm() {
   }
   nameError.value = ''
   scopesError.value = ''
+  audienceError.value = ''
 }
 
 const handleAddAccessToken = async () => {
   nameError.value = ''
   scopesError.value = ''
+  audienceError.value = ''
   const normalizedName = accessTokenToAdd.value.name.trim()
   if (!normalizedName) {
     nameError.value = String(t('accessTokenSetting.fillName'))
@@ -464,6 +480,11 @@ const handleAddAccessToken = async () => {
   if (accessTokenToAdd.value.scopes.length === 0) {
     scopesError.value = String(t('accessTokenSetting.selectScopes'))
     theToast.error(scopesError.value)
+    return
+  }
+  if (requiresIntegrationAudience.value && accessTokenToAdd.value.audience !== 'integration') {
+    audienceError.value = String(t('accessTokenSetting.commentWriteAudienceRequired'))
+    theToast.error(audienceError.value)
     return
   }
 


### PR DESCRIPTION
当前 Ech0 已具备作用域访问令牌能力，但评论模块的写入链路仍仅对公开网页端开放。

对于第三方集成场景，现有的公开表单链路因强依赖浏览器交互特性（如验证码机制），无法满足S2S的高效调用需求，因此新增了专属的 API 接口，在安全的前提下为第三方提供评论同步能力。


## Pull request overview

This PR adds a controlled “integration” comment-write API and aligns access token issuance/validation so `comment:write` tokens are only minted with a compatible audience.

**Changes:**
- Add `/api/comments/integration` endpoint gated by access-token `aud=integration` + `scope=comment:write`.
- Enforce `comment:write` ⇒ `audience=integration` both in the panel UI and in backend access-token creation validation.
- Refactor comment creation internals (shared helpers), tighten panel comment route scope requirements, and expand middleware to support “access-token-only” scope checks (with tests).

### Reviewed changes

Copilot reviewed 15 out of 15 changed files in this pull request and generated 1 comment.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| web/src/views/panel/modules/TheSetting/TheAccessTokenSetting.vue | UI hint + client-side validation requiring `audience=integration` when selecting `comment:write`. |
| web/src/locales/messages/zh-CN.json | Adds i18n strings for the new audience hint/validation message (zh-CN). |
| web/src/locales/messages/en-US.json | Adds i18n strings for the new audience hint/validation message (en-US). |
| web/src/locales/messages/de-DE.json | Adds i18n strings for the new audience hint/validation message (de-DE). |
| internal/service/setting/access_token_service.go | Backend validation: `comment:write` scope requires `AudienceIntegration`. |
| internal/service/setting/access_token_service_test.go | Tests for the new audience enforcement on access-token creation. |
| internal/service/comment/ports.go | Extends comment service interface with `CreateIntegrationComment`. |
| internal/service/comment/comment.go | Implements integration comment creation + refactors shared comment creation helpers; enhances viewer parsing to preserve token metadata. |
| internal/service/comment/comment_create_test.go | New tests for integration comment behavior and token-metadata handling. |
| internal/router/router_test.go | Ensures the new integration comment route is registered. |
| internal/router/comment.go | Registers `/comments/integration` with audience+scope middleware; adds scope middleware to panel comment routes. |
| internal/model/comment/comment.go | Introduces `CreateIntegrationCommentDto`. |
| internal/middleware/scope.go | Refactors scope enforcement; adds “access-token-only” and “required audience” variants. |
| internal/middleware/scope_test.go | Adds tests for the new middleware variants. |
| internal/handler/comment/comment.go | Adds handler for integration comment creation; switches optional viewer attachment to preserve token metadata. |
</details>


---
