### PR TITLE
fix(web): correct delete bug + make TheUploader scenario-configurable + 20 MiB image cap

### DIFF
--- a/web/src/components/advanced/TheUploader.vue
+++ b/web/src/components/advanced/TheUploader.vue
@@ -16,10 +16,12 @@
       @drop.prevent="handleDrop"
     >
       <span class="text-[var(--color-text-primary)] font-medium">
-        {{ t('uploader.dropHere') }}
+        <slot name="drop-title">{{ t('uploader.dropHere') }}</slot>
       </span>
       <span class="text-xs text-[var(--color-text-muted)]">
-        {{ t('uploader.dropHint', { max: maxFiles }) }}
+        <slot name="drop-hint" :max="maxFiles" :max-file-size="maxFileSize">
+          {{ t('uploader.dropHint', { max: maxFiles }) }}
+        </slot>
       </span>
     </button>
 
@@ -72,7 +74,7 @@
             </span>
             <div class="flex items-center gap-1.5 shrink-0">
               <span class="text-xs text-[var(--color-text-muted)]">
-                {{ formatSize(item.file.size) }}
+                {{ formatBytes(item.file.size) }}
               </span>
               <template v-for="badge in [compressionBadge(item)]" :key="badge?.label">
                 <span
@@ -169,13 +171,24 @@ import { computed, onBeforeUnmount, onMounted, ref, toRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useEditorStore } from '@/stores'
 import { useUpload, UPLOAD_STATUS, type QueueItem, type UploadStatus } from '@/lib/file/useUpload'
+import { formatBytes } from '@/utils/file'
 
-const props = defineProps<{
-  fileStorageType: App.Api.File.StorageType
-  EnableCompressor: boolean
-  fileCategory?: App.Api.File.Category
-  allowedFileTypes?: string[]
-}>()
+const props = withDefaults(
+  defineProps<{
+    fileStorageType: App.Api.File.StorageType
+    EnableCompressor: boolean
+    fileCategory?: App.Api.File.Category
+    allowedFileTypes?: string[]
+    /** Cap on the number of files in the queue (rejected entries beyond this are skipped). */
+    maxFiles?: number
+    /** Per-file size cap in bytes; files above this are rejected with a toast. Unset = no cap. */
+    maxFileSize?: number
+  }>(),
+  {
+    maxFiles: 6,
+    maxFileSize: undefined,
+  },
+)
 
 const editorStore = useEditorStore()
 const { t } = useI18n()
@@ -188,7 +201,8 @@ const allowedTypes = computed(() =>
 )
 const acceptAttr = computed(() => allowedTypes.value.join(','))
 
-const maxFiles = 6
+const maxFiles = computed(() => props.maxFiles)
+const maxFileSize = computed(() => props.maxFileSize)
 
 const { items, isUploading, totalActive, addFiles, retry, remove, moveItem, cancelAll } = useUpload(
   {
@@ -196,7 +210,8 @@ const { items, isUploading, totalActive, addFiles, retry, remove, moveItem, canc
     enableCompressor: toRef(props, 'EnableCompressor'),
     category: props.fileCategory,
     allowedTypes: allowedTypes.value,
-    maxFiles,
+    maxFiles: maxFiles.value,
+    maxFileSize: maxFileSize.value,
     concurrency: 3,
     onAllComplete: (results) => {
       editorStore.handleUppyUploaded(results)
@@ -337,21 +352,6 @@ function onItemDragEnd() {
 
 // ---------- Display helpers ----------
 
-const SIZE_UNITS = ['B', 'KB', 'MB', 'GB'] as const
-
-function formatSize(bytes: number | undefined): string {
-  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) return '—'
-  if (bytes === 0) return '0 B'
-  let value = bytes
-  let unit = 0
-  while (value >= 1024 && unit < SIZE_UNITS.length - 1) {
-    value /= 1024
-    unit++
-  }
-  const fixed = value >= 100 || unit === 0 ? value.toFixed(0) : value.toFixed(1)
-  return `${fixed} ${SIZE_UNITS[unit]}`
-}
-
 type CompressionBadge =
   | { tone: 'savings'; label: string; tooltip: string }
   | { tone: 'none'; label: string; tooltip: string }
@@ -372,8 +372,8 @@ function compressionBadge(item: QueueItem): CompressionBadge {
         tone: 'savings',
         label: `−${pct}%`,
         tooltip: t('uploader.compressionTooltip', {
-          from: formatSize(before),
-          to: formatSize(after),
+          from: formatBytes(before),
+          to: formatBytes(after),
         }),
       }
     }

--- a/web/src/lib/file/useUpload.ts
+++ b/web/src/lib/file/useUpload.ts
@@ -4,6 +4,7 @@ import { FILE_CATEGORY, FILE_STORAGE_TYPE } from '@/constants/file'
 import { useAuthStore } from '@/stores/auth'
 import { useUserStore } from '@/stores/user'
 import { theToast } from '@/utils/toast'
+import { formatBytes } from '@/utils/file'
 import { getImageSize } from '@/utils/image'
 import { compressImage, inferFileExtFromType } from './compress'
 import { getPresign, updateFileMeta } from './api/adapter'
@@ -70,6 +71,8 @@ export interface UseUploadOptions {
   category?: App.Api.File.Category
   allowedTypes?: string[]
   maxFiles?: number
+  /** Optional per-file size cap in bytes; files above this are rejected with a toast. */
+  maxFileSize?: number
   concurrency?: number
   onAllComplete: (files: App.Api.Ech0.FileToAdd[]) => void
 }
@@ -102,6 +105,7 @@ export function useUpload(opts: UseUploadOptions) {
   const category = opts.category ?? FILE_CATEGORY.IMAGE
   const allowedTypes = opts.allowedTypes?.length ? opts.allowedTypes : ['image/*']
   const maxFiles = opts.maxFiles ?? 6
+  const maxFileSize = opts.maxFileSize
   const concurrency = opts.concurrency ?? 3
 
   let inFlight = 0
@@ -132,6 +136,7 @@ export function useUpload(opts: UseUploadOptions) {
     const existingIds = new Set(items.value.map((i) => i.id))
     let remaining = Math.max(0, maxFiles - liveCount())
     let rejected = false
+    const oversized: string[] = []
 
     for (const file of files) {
       if (remaining <= 0) {
@@ -139,6 +144,10 @@ export function useUpload(opts: UseUploadOptions) {
         break
       }
       if (!isAllowed(file)) continue
+      if (maxFileSize != null && file.size > maxFileSize) {
+        oversized.push(file.name)
+        continue
+      }
       const id = genId(file)
       if (existingIds.has(id)) continue
       existingIds.add(id)
@@ -157,6 +166,16 @@ export function useUpload(opts: UseUploadOptions) {
 
     if (rejected) {
       theToast.info(String(t('uploader.maxFilesReached', { max: maxFiles })))
+    }
+    if (oversized.length > 0 && maxFileSize != null) {
+      theToast.error(
+        String(
+          t('uploader.fileTooLarge', {
+            name: oversized[0] + (oversized.length > 1 ? ` (+${oversized.length - 1})` : ''),
+            max: formatBytes(maxFileSize),
+          }),
+        ),
+      )
     }
 
     pump()

--- a/web/src/locales/messages/de-DE.json
+++ b/web/src/locales/messages/de-DE.json
@@ -113,6 +113,7 @@
     "removeImage": "Bild entfernen",
     "invalidImageIndex": "Ungültiger Bildindex – Entfernen nicht möglich",
     "removeImageConfirmTitle": "Dieses Bild entfernen?",
+    "removeImageRemoteFailed": "Bild aus dem Editor entfernt, aber serverseitiges Löschen fehlgeschlagen – die Datei könnte auf dem Backend zurückbleiben",
     "restoreDraftTitle": "Lokalen Entwurf wiederherstellen",
     "restoreDraftDesc": "Es wurde ein unveröffentlichter Entwurf gefunden. Wiederherstellen?",
     "restoreDraftRecovered": "Lokaler Entwurf wiederhergestellt",

--- a/web/src/locales/messages/de-DE.json
+++ b/web/src/locales/messages/de-DE.json
@@ -886,6 +886,7 @@
     "statusError": "Fehlgeschlagen",
     "uploadingProgress": "{active} Datei(en) werden hochgeladen…",
     "maxFilesReached": "Maximal {max} Dateien; weitere ignoriert",
+    "fileTooLarge": "{name} überschreitet das Limit von {max} pro Datei und wurde übersprungen",
     "uploadError": "Beim Hochladen ist ein Fehler aufgetreten 😢",
     "loginRequired": "Bitte zuerst anmelden, um Bilder hochzuladen 😢",
     "missingFileIdentifier": "Upload-Antwort enthält keinen Dateibezeichner – Bindung an Echo nicht möglich",

--- a/web/src/locales/messages/en-US.json
+++ b/web/src/locales/messages/en-US.json
@@ -886,6 +886,7 @@
     "statusError": "Failed",
     "uploadingProgress": "Uploading {active} file(s)...",
     "maxFilesReached": "Max {max} files; extras ignored",
+    "fileTooLarge": "{name} exceeds the {max} per-file limit; skipped",
     "uploadError": "An error occurred while uploading image 😢",
     "loginRequired": "Please log in before uploading images 😢",
     "missingFileIdentifier": "Upload response missing file identifier; cannot bind to Echo",

--- a/web/src/locales/messages/en-US.json
+++ b/web/src/locales/messages/en-US.json
@@ -113,6 +113,7 @@
     "removeImage": "Remove image",
     "invalidImageIndex": "Invalid current image index; cannot remove",
     "removeImageConfirmTitle": "Remove this image?",
+    "removeImageRemoteFailed": "Image removed from the editor, but the server delete failed; the file may remain on the backend",
     "restoreDraftTitle": "Restore local draft",
     "restoreDraftDesc": "An unpublished local draft was detected. Restore it?",
     "restoreDraftRecovered": "Local draft restored",

--- a/web/src/locales/messages/ja-JP.json
+++ b/web/src/locales/messages/ja-JP.json
@@ -886,6 +886,7 @@
     "statusError": "失敗",
     "uploadingProgress": "{active} 件をアップロード中…",
     "maxFilesReached": "最大 {max} 件まで。超過分は無視されました",
+    "fileTooLarge": "{name} はファイルサイズ上限 {max} を超えたためスキップしました",
     "uploadError": "画像のアップロード中にエラーが発生しました 😢",
     "loginRequired": "画像をアップロードするには先にログインしてください 😢",
     "missingFileIdentifier": "アップロード応答にファイル識別子が含まれていません。Echo に紐付けできないため再試行してください",

--- a/web/src/locales/messages/ja-JP.json
+++ b/web/src/locales/messages/ja-JP.json
@@ -113,6 +113,7 @@
     "removeImage": "画像を削除",
     "invalidImageIndex": "画像インデックスが無効です。削除できません！",
     "removeImageConfirmTitle": "この画像を削除しますか？",
+    "removeImageRemoteFailed": "エディタから削除しましたが、サーバー側の削除に失敗しました。バックエンドにファイルが残っている可能性があります",
     "restoreDraftTitle": "ローカル下書きを復元",
     "restoreDraftDesc": "未公開のローカル下書きが見つかりました。復元しますか？",
     "restoreDraftRecovered": "ローカル下書きを復元しました",

--- a/web/src/locales/messages/zh-CN.json
+++ b/web/src/locales/messages/zh-CN.json
@@ -113,6 +113,7 @@
     "removeImage": "移除图片",
     "invalidImageIndex": "当前图片索引无效，无法删除！",
     "removeImageConfirmTitle": "确定要移除图片吗？",
+    "removeImageRemoteFailed": "图片已从编辑器移除，但服务器删除失败，可能存在残留文件",
     "restoreDraftTitle": "恢复本地草稿",
     "restoreDraftDesc": "检测到你有未发布的本地草稿，是否恢复？",
     "restoreDraftRecovered": "已恢复本地草稿",

--- a/web/src/locales/messages/zh-CN.json
+++ b/web/src/locales/messages/zh-CN.json
@@ -886,6 +886,7 @@
     "statusError": "失败",
     "uploadingProgress": "正在上传 {active} 个文件...",
     "maxFilesReached": "最多 {max} 个文件，已忽略多余的",
+    "fileTooLarge": "{name} 超过单文件 {max} 上限，已跳过",
     "uploadError": "上传图片时发生错误 😢",
     "loginRequired": "请先登录再上传图片 😢",
     "missingFileIdentifier": "上传响应缺少文件标识，无法绑定到 Echo，请重试",

--- a/web/src/utils/file.ts
+++ b/web/src/utils/file.ts
@@ -1,0 +1,16 @@
+const SIZE_UNITS = ['B', 'KB', 'MB', 'GB'] as const
+
+// Render a byte count as a short human label (e.g. 234 KB, 1.2 MB).
+// Returns "—" for missing/invalid input rather than throwing, so it's safe in templates.
+export function formatBytes(bytes: number | undefined | null): string {
+  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) return '—'
+  if (bytes === 0) return '0 B'
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < SIZE_UNITS.length - 1) {
+    value /= 1024
+    unit++
+  }
+  const fixed = value >= 100 || unit === 0 ? value.toFixed(0) : value.toFixed(1)
+  return `${fixed} ${SIZE_UNITS[unit]}`
+}

--- a/web/src/views/home/modules/TheEditor/TheEditorImage.vue
+++ b/web/src/views/home/modules/TheEditor/TheEditorImage.vue
@@ -10,7 +10,8 @@
   >
     <button
       @click="handleRemoveImage"
-      class="absolute -top-3 -right-4 bg-[var(--color-accent-soft)] hover:bg-[var(--color-danger)]/30 text-[var(--color-text-secondary)] rounded-lg w-7 h-7 flex items-center justify-center shadow-[var(--shadow-sm)]"
+      :disabled="isDeleting"
+      class="absolute -top-3 -right-4 bg-[var(--color-accent-soft)] hover:bg-[var(--color-danger)]/30 text-[var(--color-text-secondary)] rounded-lg w-7 h-7 flex items-center justify-center shadow-[var(--shadow-sm)] disabled:opacity-60 disabled:cursor-not-allowed"
       v-tooltip="t('editor.removeImage')"
     >
       <Close class="w-4 h-4" />
@@ -75,6 +76,7 @@ const { t } = useI18n()
 // const emit = defineEmits(['handleAddorUpdateEcho'])
 
 const fileIndex = ref<number>(0) // 临时文件索引变量
+const isDeleting = ref<boolean>(false)
 const echoStore = useEchoStore()
 const { echoToUpdate } = storeToRefs(echoStore)
 const editorStore = useEditorStore()
@@ -90,6 +92,7 @@ const previewItems = computed(() =>
 const { open: openPreview } = usePhotoSwipeGallery(previewItems)
 
 const handleRemoveImage = () => {
+  if (isDeleting.value) return
   if (
     fileIndex.value < 0 ||
     fileIndex.value >= filesToAdd.value.length ||
@@ -103,31 +106,38 @@ const handleRemoveImage = () => {
   openConfirm({
     title: String(t('editor.removeImageConfirmTitle')),
     description: '',
-    onConfirm: () => {
-      const fileToDelete: App.Api.Ech0.FileToDelete = {
-        id: String(filesToAdd.value[index]?.id || ''),
-      }
+    onConfirm: async () => {
+      if (isDeleting.value) return
+      const target = filesToAdd.value[index]
+      const fileId = String(target?.id || '')
+      const source = String(target?.storage_type || '')
+      const needsRemoteDelete =
+        (source === FILE_STORAGE_TYPE.LOCAL || source === FILE_STORAGE_TYPE.OBJECT) && !!fileId
 
-      const source = String(filesToAdd.value[index]?.storage_type || '')
-      if (
-        (source === FILE_STORAGE_TYPE.LOCAL || source === FILE_STORAGE_TYPE.OBJECT) &&
-        fileToDelete.id
-      ) {
-        deleteFileById(fileToDelete.id).then(() => {
-          // 这里不管图片是否远程删除成功都强制删除图片
-          // 从数组中删除图片
-          editorStore.removeFileAt(index)
-
-          // 如果删除成功且当前处于Echo更新模式，则需要立马执行更新（图片删除操作不可逆，需要立马更新确保后端数据同步）
-          if (isUpdateMode.value && echoToUpdate.value) {
-            editorStore.handleAddOrUpdateEcho(true)
+      isDeleting.value = true
+      try {
+        if (needsRemoteDelete) {
+          try {
+            await deleteFileById(fileId)
+          } catch {
+            // Per design, local removal proceeds even if the backend delete fails;
+            // surface a warning so the user knows the backend file may be orphaned.
+            theToast.error(String(t('editor.removeImageRemoteFailed')))
           }
-        })
-      } else {
-        editorStore.removeFileAt(index)
-      }
+        }
 
-      fileIndex.value = 0
+        editorStore.removeFileAt(index)
+
+        // Keep the carousel near the removed slot rather than snapping back to 0.
+        const nextLen = filesToAdd.value.length
+        fileIndex.value = nextLen === 0 ? 0 : Math.min(index, nextLen - 1)
+
+        if (isUpdateMode.value && echoToUpdate.value) {
+          editorStore.handleAddOrUpdateEcho(true)
+        }
+      } finally {
+        isDeleting.value = false
+      }
     },
   })
 }

--- a/web/src/views/home/modules/TheEditor/TheImageEditor.vue
+++ b/web/src/views/home/modules/TheEditor/TheImageEditor.vue
@@ -72,6 +72,7 @@
         v-if="fileToAdd.storage_type !== FILE_STORAGE_TYPE.EXTERNAL"
         :fileStorageType="fileToAdd.storage_type"
         :EnableCompressor="enableCompressor"
+        :maxFileSize="IMAGE_MAX_FILE_SIZE"
       />
 
       <!-- 图片直链 -->
@@ -113,6 +114,10 @@ import BaseInput from '@/components/common/BaseInput.vue'
 import TheUploader from '@/components/advanced/TheUploader.vue'
 import { localStg } from '@/utils/storage'
 import { useI18n } from 'vue-i18n'
+
+// Mirror the backend's default image upload cap (config.go: ImageMaxSize = 20 MiB)
+// so an oversized file is rejected up-front instead of after a wasted upload.
+const IMAGE_MAX_FILE_SIZE = 20 * 1024 * 1024
 
 const editorStore = useEditorStore()
 const { fileToAdd, fileUploading, echoToAdd } = storeToRefs(editorStore)


### PR DESCRIPTION
## Summary

Three small, independent fixes/enhancements to the editor file flow that piled up while we were planning the bigger `TheEditorImage` consolidation:

1. **Fix a real bug in `TheEditorImage` delete** — comment said "force-remove regardless of remote delete success" but the local `removeFileAt` was nested in `.then()`, so a failed `deleteFileById` left the image stuck with no error surfaced. Now: try/catch + i18n toast on remote-delete failure + still removes locally.
2. **Repeat-click race in delete** — added `isDeleting` ref, button gets `:disabled` and the early return guards re-entry into `onConfirm`.
3. **`fileIndex` no longer snaps to 0** after delete — clamps to `Math.min(index, length - 1)` so users stay near where they were.
4. **`TheUploader` is now scenario-configurable** without a presets table (deferred per YAGNI):
   - `maxFiles` promoted from hardcoded constant to prop (default 6)
   - new `maxFileSize?: number` prop — when set, oversized files are rejected at `addFiles()` with an i18n'd toast (`uploader.fileTooLarge`)
   - new `drop-title` / `drop-hint` slots so callers can override the drop-zone copy without forking the component
   - extracted `formatBytes()` to `web/src/utils/file.ts` so the component (display) and `useUpload` (oversize toast) share one formatter
5. **20 MiB frontend cap on image uploads** — mirrors the backend default `ImageMaxSize` so a 100 MB pick is rejected up-front instead of after a wasted upload round-trip.

## Commits

- `a36a0648` fix(web): correct delete behaviour in TheEditorImage
- `dd0444e4` feat(web): make TheUploader configurable per scenario
- `9e5ee70a` feat(web): cap image uploads at 20 MiB on the frontend

## Verification

- `pnpm -C web type-check`: clean
- `pnpm -C web test:unit`: 34/34 pass
- `pnpm -C web run i18n:check`: green (added `uploader.fileTooLarge` and `editor.removeImageRemoteFailed` to all 4 locales)
- `pnpm -C web exec eslint`: clean

## Test plan

- [ ] Edit an existing echo's image → click ✕ → confirm → image removed; if the API call fails, toast appears AND image is still removed locally
- [ ] Click ✕ rapidly during delete → button disabled, no double-fire
- [ ] Browse to image #5 of #6 → delete it → carousel stays at #5 (now showing what was #6), not snapping to #1
- [ ] Try uploading a >20 MiB image → immediate toast naming the file and showing "20 MB" limit; nothing uploads
- [ ] Normal image upload still works exactly as before

## Out of scope

- The actual `TheEditorImage` consolidation into the uploader queue (steps A-D from the earlier plan) — left for a follow-up branch since it requires bigger architectural changes (uploader rendering `editorStore.filesToAdd` directly, PhotoSwipe wiring on thumbnails, server-delete + update-mode resync moved into the uploader's remove button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)