### PR TITLE
feat: About page, internal/version package, SPDX headers (AGPL §13)

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -2,7 +2,7 @@ root = "."
 tmp_dir = "tmp"
 
 [build]
-cmd = "go build -o ./tmp/main ./cmd/ech0"
+cmd = "go build -ldflags \"-X github.com/lin-snow/ech0/internal/version.Commit=$(git rev-parse --short HEAD 2>/dev/null || echo unknown) -X github.com/lin-snow/ech0/internal/version.BuildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)\" -o ./tmp/main ./cmd/ech0"
 entrypoint = ["./tmp/main", "serve"]
 include_ext = ["go", "yaml", "yml", "toml", "json"]
 exclude_dir = ["tmp", "web", "data", "backup", "template", "node_modules", ".git", ".idea", ".vscode"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,11 @@ jobs:
           ARM64_TOOLCHAIN: ${{ env.ARM64_TOOLCHAIN }}
         run: |
           set -euo pipefail
-          # Define linker flags for a static build
-          STATIC_LDFLAGS="-linkmode external -extldflags '-static'"
+          # Define linker flags for a static build + inject commit / build time so /hello returns the real values.
+          GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+          BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          VERSION_PKG="github.com/lin-snow/ech0/internal/version"
+          STATIC_LDFLAGS="-linkmode external -extldflags '-static' -X ${VERSION_PKG}.Commit=${GIT_COMMIT} -X ${VERSION_PKG}.BuildTime=${BUILD_TIME}"
           OUTPUT_NAME="ech0-${{ matrix.goos }}-${{ matrix.goarch }}"
 
           if [ "${{ matrix.goarch }}" = "arm64" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ yarn-error.log
 /data/*
 temp
 tmp/
+bin/
 build-errors.log
 **/node_modules
 template/dist/**

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,14 @@
 GOHOSTOS:=$(shell go env GOHOSTOS)
 GOHOSTARCH:=$(shell go env GOHOSTARCH)
 GOPATH:=$(shell go env GOPATH)
-VERSION=$(shell git describe --tags --always)
-BUILD_TIME=$(shell date +%Y-%m-%dT%H:%M:%S)
-GIT_COMMIT=$(shell git rev-parse HEAD)
+VERSION=$(shell git describe --tags --always 2>/dev/null || echo unknown)
+BUILD_TIME=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+GIT_COMMIT=$(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+# Inject build metadata into the binary so /hello can return the real commit/time.
+# 这两个变量必须是 var（不能是 const），见 internal/version/version.go。
+VERSION_PKG=github.com/lin-snow/ech0/internal/version
+LDFLAGS=-X $(VERSION_PKG).Commit=$(GIT_COMMIT) -X $(VERSION_PKG).BuildTime=$(BUILD_TIME)
 
 # Docker variables
 DOCKER_REGISTRY?=sn0wl1n
@@ -13,7 +18,7 @@ IMAGE_TAG?=latest
 OS?=$(if $(GOHOSTOS),$(GOHOSTOS),linux)
 ARCH?=$(if $(GOHOSTARCH),$(GOHOSTARCH),amd64)
 
-.PHONY: help air-install run dev web-dev check dev-lint lint fmt test wire wire-check swagger build-image push-image
+.PHONY: help air-install run dev web-dev check dev-lint lint fmt test wire wire-check swagger build build-image push-image
 
 AIR_BIN := $(shell command -v air 2>/dev/null || echo "$(GOPATH)/bin/air")
 
@@ -23,6 +28,7 @@ help:
 	@echo "  make dev         - Run backend with Air hot reload"
 	@echo "  make air-install - Install Air to GOPATH/bin"
 	@echo "  make web-dev     - Run frontend dev server"
+	@echo "  make build       - Build local binary with version/commit injected"
 	@echo "  make check       - Backend fmt/lint + web format/lint + i18n checks"
 	@echo "  make dev-lint    - Backend fmt/lint + web format/lint + i18n checks"
 	@echo "  make lint        - Run golangci-lint checks"
@@ -38,7 +44,10 @@ air-install:
 	go install github.com/air-verse/air@latest
 
 run:
-	go run ./cmd/ech0 serve
+	go run -ldflags "$(LDFLAGS)" ./cmd/ech0 serve
+
+build:
+	go build -ldflags "$(LDFLAGS)" -o ./bin/ech0 ./cmd/ech0
 
 dev:
 	@if [ ! -x "$(AIR_BIN)" ]; then \
@@ -93,6 +102,8 @@ build-image:
 	docker build --platform $(OS)/$(ARCH) \
 		--build-arg TARGETOS=$(OS) \
 		--build-arg TARGETARCH=$(ARCH) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg BUILD_TIME=$(BUILD_TIME) \
 		-t $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG) -f docker/build.Dockerfile .
 push-image:
 	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cmd
 
 import (

--- a/cmd/ech0/main.go
+++ b/cmd/ech0/main.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package main
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cmd
 
 import (

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cmd
 
 import (

--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -34,11 +34,17 @@ COPY --from=frontend-builder /template/dist /app/template/dist
 
 ARG TARGETOS
 ARG TARGETARCH
+# 构建元数据：commit / build_time。当宿主传入了 ARG（make build-image 默认会传），
+# 直接使用；否则回退到容器内 git / date（要求构建上下文包含 .git）。
+ARG GIT_COMMIT
+ARG BUILD_TIME
 
 # 与 release.yml「Build backend binary with embedded frontend」一致（embed 读取 template/dist）
-RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+RUN COMMIT="${GIT_COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}" \
+    && BUILD="${BUILD_TIME:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}" \
+    && CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -tags netgo \
-    -ldflags="-linkmode external -extldflags '-static'" \
+    -ldflags="-linkmode external -extldflags '-static' -X github.com/lin-snow/ech0/internal/version.Commit=${COMMIT} -X github.com/lin-snow/ech0/internal/version.BuildTime=${BUILD}" \
     -o ech0 ./cmd/ech0/main.go
 
 # =================== 最终镜像（对齐根目录 Dockerfile 运行时层）===================

--- a/hub/src/App.vue
+++ b/hub/src/App.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
 </script>

--- a/hub/src/components/HubActiveCreators.vue
+++ b/hub/src/components/HubActiveCreators.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import { ref, watch } from 'vue'
 import BaseAvatar from '@/components/common/BaseAvatar.vue'

--- a/hub/src/components/HubEchoCard.vue
+++ b/hub/src/components/HubEchoCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 /** 结构与 web/src/components/advanced/echo/cards/TheHubEcho.vue 一致（Hub 聚合侧不展示 Extension）。 */
 import Verified from '@/components/icons/verified.vue'

--- a/hub/src/components/HubHomeFoliageCanvas.vue
+++ b/hub/src/components/HubHomeFoliageCanvas.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 

--- a/hub/src/components/HubToast.vue
+++ b/hub/src/components/HubToast.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import { onBeforeUnmount, ref, watch } from 'vue'
 

--- a/hub/src/composables/useHubMergeFeed.ts
+++ b/hub/src/composables/useHubMergeFeed.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /**
  * 与 web/src/stores/hub.ts 对齐的多源归并：
  * 每实例独立缓冲池 + 按 createdTs 全局多路归并取数（batchSize 条/批）。

--- a/hub/src/constants/echo.ts
+++ b/hub/src/constants/echo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /** 与 web/src/enums/enums 中 ImageLayout 取值一致，避免 Hub 直接依赖 web 的 enum 编译选项冲突 */
 export const ImageLayout = {
   WATERFALL: 'waterfall',

--- a/hub/src/hubSeo.ts
+++ b/hub/src/hubSeo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { RouteLocationNormalized } from 'vue-router'
 
 /** Public origin for canonical, Open Graph, and sitemap (override via `VITE_HUB_SITE_ORIGIN`). */

--- a/hub/src/i18n.ts
+++ b/hub/src/i18n.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { createI18n } from 'vue-i18n'
 import enUS from '../../web/src/locales/messages/en-US.json'
 

--- a/hub/src/main.ts
+++ b/hub/src/main.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import 'virtual:uno.css'
 import '../../web/src/themes/index.scss'
 /** 首屏前为 html 固定挂上 light（Hub 仅 light 主题） */

--- a/hub/src/router/index.ts
+++ b/hub/src/router/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { createRouter, createWebHistory } from 'vue-router'
 import { applyHubRouteMeta } from '../hubSeo'
 import HomeView from '../views/HomeView.vue'

--- a/hub/src/services/connectApi.ts
+++ b/hub/src/services/connectApi.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { HubInstance } from '../types/hub'
 import type { ApiResult } from '../types/echo'
 import { timeoutSignal } from '../utils/fetchTimeout'

--- a/hub/src/services/echoApi.ts
+++ b/hub/src/services/echoApi.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { ApiResult, EchoPost, EchoQueryPage } from '../types/echo'
 import { timeoutSignal } from '../utils/fetchTimeout'
 import { timeValueToUnixSeconds } from '../utils/timeValue'

--- a/hub/src/services/healthz.ts
+++ b/hub/src/services/healthz.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { ApiResult } from '../types/echo'
 import { timeoutSignal } from '../utils/fetchTimeout'
 

--- a/hub/src/services/loadHubConfig.ts
+++ b/hub/src/services/loadHubConfig.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { HubConfig, HubInstance } from '../types/hub'
 
 function stripTrailingSlash(u: string): string {

--- a/hub/src/services/probeInstances.ts
+++ b/hub/src/services/probeInstances.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { fetchHealthz, meetsHubMinVersion, getMinSupportedVersion } from './healthz'
 import type { HubInstance } from '../types/hub'
 import { HUB_FAN_OUT_LIMIT, pMapLimit } from '../utils/pMapLimit'

--- a/hub/src/shims/utils-other.ts
+++ b/hub/src/shims/utils-other.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /**
  * 替代 web/src/utils/other.ts 中被 TheImageGallery 使用的图片 URL 解析，
  * 避免整文件顶部的 i18n / enums 依赖把整站 web 打进 Hub bundle。

--- a/hub/src/syncWebTheme.ts
+++ b/hub/src/syncWebTheme.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /**
  * Hub 仅使用 **light** 语义主题（`web` 的 `:root.light`，见 themes/tokens/semantic.light.scss）。
  * 不读取 localStorage、不响应 dark / sunny，避免与主站主题设置串台。

--- a/hub/src/types/echo.ts
+++ b/hub/src/types/echo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /** 与后端 Echo 模型对齐（见 internal/model/echo） */
 export interface EchoTag {
   id: string

--- a/hub/src/types/hub.ts
+++ b/hub/src/types/hub.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export interface HubInstance {
   id: string
   url: string

--- a/hub/src/utils/echoFiles.ts
+++ b/hub/src/utils/echoFiles.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /**
  * 与 web/src/utils/echo.ts 等价，但仅从 @/lib/file/selectors 引入 filter，
  * 避免 @/lib/file 的 barrel 把整个 file 子系统打进 Hub。

--- a/hub/src/utils/fetchTimeout.ts
+++ b/hub/src/utils/fetchTimeout.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /**
  * 跨实例 fetch 的硬超时信号。没有它，单个吊死的实例会让首页/探索页等到
  * 浏览器默认超时（30s+）才放手；扇出到 100 个实例时这是首要瓶颈。

--- a/hub/src/utils/formatHubDate.ts
+++ b/hub/src/utils/formatHubDate.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { timeValueToMs } from './timeValue'
 
 /** Hub 卡片底部时间展示（不依赖 web/utils/other 的 i18n 相对时间链） */

--- a/hub/src/utils/hubLinks.ts
+++ b/hub/src/utils/hubLinks.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /** 加入 Hub（GitHub Issue）链接，部署时可覆盖 */
 
 const trim = (v: string | undefined) => (v ?? '').trim()

--- a/hub/src/utils/hubUrl.ts
+++ b/hub/src/utils/hubUrl.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /** 与实例清单、缓冲池 Map 键一致，避免末尾斜杠导致 logo 对不上 */
 export function normalizeHubInstanceUrl(url: string): string {
   return url.trim().replace(/\/+$/, '')

--- a/hub/src/utils/pMapLimit.ts
+++ b/hub/src/utils/pMapLimit.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /**
  * 受限并发版的 `Promise.allSettled`：保留入参顺序、不因单项失败拒绝整体。
  *

--- a/hub/src/utils/resolveHubLogoUrl.ts
+++ b/hub/src/utils/resolveHubLogoUrl.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { normalizeHubInstanceUrl } from './hubUrl'
 
 /**

--- a/hub/src/utils/storage.ts
+++ b/hub/src/utils/storage.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /** 与 web/src/utils/storage.ts 一致，避免从 web 拉取无关依赖 */
 export const localStg = {
   setItem<T>(key: string, obj: T) {

--- a/hub/src/utils/timeValue.ts
+++ b/hub/src/utils/timeValue.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /**
  * 将「存储层时间」统一为毫秒时间戳。
  *

--- a/hub/src/views/ExploreView.vue
+++ b/hub/src/views/ExploreView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import { computed, onMounted, onBeforeUnmount, ref, watch, nextTick } from 'vue'
 import { useMediaQuery } from '@vueuse/core'

--- a/hub/src/views/HomeView.vue
+++ b/hub/src/views/HomeView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { RouterLink } from 'vue-router'

--- a/hub/src/vite-env.d.ts
+++ b/hub/src/vite-env.d.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
 

--- a/hub/uno.config.ts
+++ b/hub/uno.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineConfig } from 'unocss'
 import presetWind4 from '@unocss/preset-wind4'
 

--- a/hub/vite.config.ts
+++ b/hub/vite.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package agent
 
 import (

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package app
 
 import (

--- a/internal/app/component.go
+++ b/internal/app/component.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package app
 
 import "context"

--- a/internal/app/errors.go
+++ b/internal/app/errors.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package app
 
 import "fmt"

--- a/internal/app/options.go
+++ b/internal/app/options.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package app
 
 import (

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package app
 
 import (

--- a/internal/async/pool.go
+++ b/internal/async/pool.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package async
 
 import (

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package bootstrap
 
 import (

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cache
 
 import (

--- a/internal/cache/patterns.go
+++ b/internal/cache/patterns.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cache
 
 import (

--- a/internal/cache/patterns_test.go
+++ b/internal/cache/patterns_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cache
 
 import (

--- a/internal/cache/provider.go
+++ b/internal/cache/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cache
 
 import "github.com/google/wire"

--- a/internal/cache/restretto.go
+++ b/internal/cache/restretto.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cache
 
 import (

--- a/internal/cache/restretto_test.go
+++ b/internal/cache/restretto_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cache
 
 import (

--- a/internal/captcha/gocap.go
+++ b/internal/captcha/gocap.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package captcha
 
 import (

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package cli
 
 import (
@@ -10,8 +13,8 @@ import (
 	"github.com/lin-snow/ech0/internal/backup"
 	"github.com/lin-snow/ech0/internal/config"
 	"github.com/lin-snow/ech0/internal/di"
-	commonModel "github.com/lin-snow/ech0/internal/model/common"
 	"github.com/lin-snow/ech0/internal/tui"
+	versionPkg "github.com/lin-snow/ech0/internal/version"
 )
 
 func isWebPortInUse() bool {
@@ -68,7 +71,7 @@ func DoBackup() {
 func DoVersion() {
 	item := struct{ Title, Msg string }{
 		Title: "📦 当前版本",
-		Msg:   "v" + commonModel.Version,
+		Msg:   "v" + versionPkg.Version,
 	}
 	tui.PrintCLIWithBox(item)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package config
 
 import (

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package database
 
 import (

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package database
 
 import (

--- a/internal/database/migration/agent_provider_collapse_migrator.go
+++ b/internal/database/migration/agent_provider_collapse_migrator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration
 
 import (

--- a/internal/database/migration/legacy_table_drop_migrators.go
+++ b/internal/database/migration/legacy_table_drop_migrators.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration
 
 import (

--- a/internal/database/migration/legacy_table_drop_migrators_test.go
+++ b/internal/database/migration/legacy_table_drop_migrators_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration_test
 
 import (

--- a/internal/database/migration/migrator.go
+++ b/internal/database/migration/migrator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration
 
 import (

--- a/internal/database/migration/time_migration_plan.go
+++ b/internal/database/migration/time_migration_plan.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration
 
 type TimeColumnPlan struct {

--- a/internal/database/migration/time_normalizer.go
+++ b/internal/database/migration/time_normalizer.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration
 
 import (

--- a/internal/database/migration/time_normalizer_test.go
+++ b/internal/database/migration/time_normalizer_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration_test
 
 import (

--- a/internal/database/migration/time_pipeline_test.go
+++ b/internal/database/migration/time_pipeline_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration_test
 
 import (

--- a/internal/database/migration/time_sanitize_migrator.go
+++ b/internal/database/migration/time_sanitize_migrator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration
 
 import (

--- a/internal/database/migration/time_schema_rebuild_migrator.go
+++ b/internal/database/migration/time_schema_rebuild_migrator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration
 
 import (

--- a/internal/database/migration/time_unix_migrator.go
+++ b/internal/database/migration/time_unix_migrator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration
 
 import (

--- a/internal/database/migration/time_validate_migrator.go
+++ b/internal/database/migration/time_validate_migrator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migration
 
 import (

--- a/internal/database/provider.go
+++ b/internal/database/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package database
 
 import (

--- a/internal/di/wire.go
+++ b/internal/di/wire.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 //go:generate go run -mod=mod github.com/google/wire/cmd/wire
 //go:build wireinject
 // +build wireinject

--- a/internal/event/bus/bus.go
+++ b/internal/event/bus/bus.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package bus
 
 import (

--- a/internal/event/bus/component.go
+++ b/internal/event/bus/component.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package bus
 
 import (

--- a/internal/event/bus/log_helpers.go
+++ b/internal/event/bus/log_helpers.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package bus
 
 import "reflect"

--- a/internal/event/contracts/contracts.go
+++ b/internal/event/contracts/contracts.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package contracts
 
 import (

--- a/internal/event/publisher/publisher.go
+++ b/internal/event/publisher/publisher.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package publisher
 
 import (

--- a/internal/event/registry/options.go
+++ b/internal/event/registry/options.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package registry
 
 import (

--- a/internal/event/registry/provider.go
+++ b/internal/event/registry/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package registry
 
 type RegisteredRegistrar struct {

--- a/internal/event/registry/registrar.go
+++ b/internal/event/registry/registrar.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package registry
 
 import (

--- a/internal/event/registry/subscriptions.go
+++ b/internal/event/registry/subscriptions.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package registry
 
 import (

--- a/internal/event/registry/webhook_subscriptions.go
+++ b/internal/event/registry/webhook_subscriptions.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package registry
 
 import (

--- a/internal/event/subscriber/agent.go
+++ b/internal/event/subscriber/agent.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package subscriber
 
 import (

--- a/internal/event/subscriber/deadletter.go
+++ b/internal/event/subscriber/deadletter.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package subscriber
 
 import (

--- a/internal/event/subscriber/scheduler.go
+++ b/internal/event/subscriber/scheduler.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package subscriber
 
 import (

--- a/internal/handler/agent/agent.go
+++ b/internal/handler/agent/agent.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/auth/auth.go
+++ b/internal/handler/auth/auth.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // Package handler 提供认证相关的 HTTP 端点：token 刷新、登出、OAuth code 交换。
 //
 // 这三个端点均为公开路由（不经过 JWTAuthMiddleware），因为：

--- a/internal/handler/auth/auth_handler_test.go
+++ b/internal/handler/auth/auth_handler_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/auth/login.go
+++ b/internal/handler/auth/login.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/auth/oauth.go
+++ b/internal/handler/auth/oauth.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/auth/passkey.go
+++ b/internal/handler/auth/passkey.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/bundle.go
+++ b/internal/handler/bundle.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/comment/comment.go
+++ b/internal/handler/comment/comment.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/common/common.go
+++ b/internal/handler/common/common.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (
@@ -13,6 +16,7 @@ import (
 	service "github.com/lin-snow/ech0/internal/service/common"
 	errorUtil "github.com/lin-snow/ech0/internal/util/err"
 	timezoneUtil "github.com/lin-snow/ech0/internal/util/timezone"
+	versionPkg "github.com/lin-snow/ech0/internal/version"
 )
 
 type CommonHandler struct {
@@ -73,14 +77,17 @@ func (commonHandler *CommonHandler) GetRss(ctx *gin.Context) {
 
 func (commonHandler *CommonHandler) HelloEch0() gin.HandlerFunc {
 	return res.Execute(func(ctx *gin.Context) res.Response {
+		// Embeds versionPkg.Info so version / commit / build_time / license /
+		// author / repo_url are all flattened into the JSON top level — the
+		// frontend About page reads them directly as the single source of truth.
 		hello := struct {
-			Hello   string `json:"hello"`
-			Version string `json:"version"`
-			Github  string `json:"github"`
+			Hello     string `json:"hello"`
+			Copyright string `json:"copyright"`
+			versionPkg.Info
 		}{
-			Hello:   "Hello, Ech0! 👋",
-			Version: commonModel.Version,
-			Github:  "https://github.com/lin-snow/Ech0",
+			Hello:     "Hello, Ech0! 👋",
+			Copyright: versionPkg.Copyright(),
+			Info:      versionPkg.Get(),
 		}
 
 		return res.Response{
@@ -99,7 +106,7 @@ func (commonHandler *CommonHandler) Healthz() gin.HandlerFunc {
 				Version string `json:"version"`
 			}{
 				Status:  "ok",
-				Version: commonModel.Version,
+				Version: versionPkg.Version,
 			},
 		}
 	})

--- a/internal/handler/connect/connect.go
+++ b/internal/handler/connect/connect.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/dashboard/dashboard.go
+++ b/internal/handler/dashboard/dashboard.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (
@@ -13,6 +16,7 @@ import (
 	githubUtil "github.com/lin-snow/ech0/internal/util/github"
 	jwtUtil "github.com/lin-snow/ech0/internal/util/jwt"
 	logUtil "github.com/lin-snow/ech0/internal/util/log"
+	versionPkg "github.com/lin-snow/ech0/internal/version"
 	"go.uber.org/zap"
 	"golang.org/x/mod/semver"
 )
@@ -110,13 +114,13 @@ func (dashboardHandler *DashboardHandler) CheckUpdate() gin.HandlerFunc {
 			return res.Response{Msg: "检查更新失败", Err: err}
 		}
 
-		cur := semver.Canonical("v" + strings.TrimPrefix(strings.TrimSpace(commonModel.Version), "v"))
+		cur := semver.Canonical("v" + strings.TrimPrefix(strings.TrimSpace(versionPkg.Version), "v"))
 		lat := semver.Canonical("v" + strings.TrimPrefix(strings.TrimSpace(latestVersion), "v"))
 		hasUpdate := cur != "" && lat != "" && semver.Compare(lat, cur) > 0
 
 		return res.Response{
 			Data: gin.H{
-				"current_version": commonModel.Version,
+				"current_version": versionPkg.Version,
 				"latest_version":  latestVersion,
 				"has_update":      hasUpdate,
 			},

--- a/internal/handler/echo/echo.go
+++ b/internal/handler/echo/echo.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/file/file.go
+++ b/internal/handler/file/file.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/init/init.go
+++ b/internal/handler/init/init.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/migration/migration.go
+++ b/internal/handler/migration/migration.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/provider.go
+++ b/internal/handler/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/response/response.go
+++ b/internal/handler/response/response.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/setting/setting.go
+++ b/internal/handler/setting/setting.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/user/user.go
+++ b/internal/handler/user/user.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/web/web.go
+++ b/internal/handler/web/web.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/handler/web/web_test.go
+++ b/internal/handler/web/web_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package handler
 
 import (

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package i18n
 
 import (

--- a/internal/i18n/json_unmarshal.go
+++ b/internal/i18n/json_unmarshal.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package i18n
 
 import "encoding/json"

--- a/internal/mcp/adapter.go
+++ b/internal/mcp/adapter.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/adapter_agent.go
+++ b/internal/mcp/adapter_agent.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/adapter_comment.go
+++ b/internal/mcp/adapter_comment.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/adapter_common.go
+++ b/internal/mcp/adapter_common.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/adapter_connect.go
+++ b/internal/mcp/adapter_connect.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/adapter_echo.go
+++ b/internal/mcp/adapter_echo.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/adapter_file.go
+++ b/internal/mcp/adapter_file.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/adapter_user.go
+++ b/internal/mcp/adapter_user.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/adapter_webhook.go
+++ b/internal/mcp/adapter_webhook.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/capability.go
+++ b/internal/mcp/capability.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 const (

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import "encoding/json"

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 type ResourceDefinition struct {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (
@@ -9,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	commonModel "github.com/lin-snow/ech0/internal/model/common"
 	logUtil "github.com/lin-snow/ech0/internal/util/log"
+	versionPkg "github.com/lin-snow/ech0/internal/version"
 	"github.com/lin-snow/ech0/pkg/viewer"
 	"go.uber.org/zap"
 )
@@ -52,7 +55,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{
 			"status":  "ok",
 			"name":    ServerName,
-			"version": commonModel.Version,
+			"version": versionPkg.Version,
 		})
 	default:
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
@@ -136,7 +139,7 @@ func (s *Server) handleInitialize() (*InitializeResult, *RPCError) {
 		},
 		ServerInfo: ServerInfo{
 			Name:    ServerName,
-			Version: commonModel.Version,
+			Version: versionPkg.Version,
 		},
 	}, nil
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 import (

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package mcp
 
 type ToolDefinition struct {

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/maintenance.go
+++ b/internal/middleware/maintenance.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/nocache.go
+++ b/internal/middleware/nocache.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/origin.go
+++ b/internal/middleware/origin.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/origin_test.go
+++ b/internal/middleware/origin_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/scope.go
+++ b/internal/middleware/scope.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/scope_test.go
+++ b/internal/middleware/scope_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/middleware/staticfile.go
+++ b/internal/middleware/staticfile.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package middleware
 
 import (

--- a/internal/migrator/contracts.go
+++ b/internal/migrator/contracts.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migrator
 
 import "github.com/lin-snow/ech0/internal/migrator/spec"

--- a/internal/migrator/extractor/ech0v4/extractor.go
+++ b/internal/migrator/extractor/ech0v4/extractor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package ech0v4
 
 import (

--- a/internal/migrator/extractor/ech0v4/extractor_test.go
+++ b/internal/migrator/extractor/ech0v4/extractor_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package ech0v4
 
 import (

--- a/internal/migrator/extractor/memos/extractor.go
+++ b/internal/migrator/extractor/memos/extractor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package memos
 
 import (

--- a/internal/migrator/factory.go
+++ b/internal/migrator/factory.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migrator
 
 import (

--- a/internal/migrator/load/noop_loader.go
+++ b/internal/migrator/load/noop_loader.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package load
 
 import (

--- a/internal/migrator/pipeline.go
+++ b/internal/migrator/pipeline.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migrator
 
 import (

--- a/internal/migrator/provider.go
+++ b/internal/migrator/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migrator
 
 import "github.com/google/wire"

--- a/internal/migrator/spec/spec.go
+++ b/internal/migrator/spec/spec.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package spec
 
 import "context"

--- a/internal/migrator/transform/default_transformer.go
+++ b/internal/migrator/transform/default_transformer.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package transform
 
 import (

--- a/internal/migrator/validate/default_validator.go
+++ b/internal/migrator/validate/default_validator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package validate
 
 import (

--- a/internal/migrator/worker.go
+++ b/internal/migrator/worker.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package migrator
 
 import (

--- a/internal/model/auth/auth.go
+++ b/internal/model/auth/auth.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import (

--- a/internal/model/auth/auth_dto.go
+++ b/internal/model/auth/auth_dto.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // LoginDto 是用户登录时的请求数据传输对象

--- a/internal/model/auth/scope.go
+++ b/internal/model/auth/scope.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // Token 类型常量，对应 JWT claims 中的 "typ" 字段。

--- a/internal/model/comment/comment.go
+++ b/internal/model/comment/comment.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import (

--- a/internal/model/common/common.go
+++ b/internal/model/common/common.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // Heatmap 用于存储热力图数据
@@ -107,8 +110,3 @@ type PageQueryResult[T any] struct {
 	Total int64 `json:"total"`
 	Items T     `json:"items"`
 }
-
-const (
-	// Version 是当前版本号
-	Version = "4.6.4"
-)

--- a/internal/model/common/common_dto.go
+++ b/internal/model/common/common_dto.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // PageQueryDto 用于分页查询的请求数据传输对象

--- a/internal/model/common/error.go
+++ b/internal/model/common/error.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import "fmt"

--- a/internal/model/common/i18n_keys.go
+++ b/internal/model/common/i18n_keys.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 const (

--- a/internal/model/common/panic.go
+++ b/internal/model/common/panic.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // Panic Constants

--- a/internal/model/common/result.go
+++ b/internal/model/common/result.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // Result 定义统一的API响应格式

--- a/internal/model/common/success.go
+++ b/internal/model/common/success.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // SUCCESS_MESSAGE 成功相关的消息常量

--- a/internal/model/connect/connect.go
+++ b/internal/model/connect/connect.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import (

--- a/internal/model/echo/echo.go
+++ b/internal/model/echo/echo.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import (

--- a/internal/model/echo/echo_dto.go
+++ b/internal/model/echo/echo_dto.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 type EchoExtensionDto struct {

--- a/internal/model/file/file.go
+++ b/internal/model/file/file.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import (

--- a/internal/model/init/init.go
+++ b/internal/model/init/init.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // Status 表示系统初始化状态。

--- a/internal/model/migration/job.go
+++ b/internal/model/migration/job.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 const (

--- a/internal/model/migration/migration_dto.go
+++ b/internal/model/migration/migration_dto.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 type CreateMigrationJobRequest struct {

--- a/internal/model/queue/queue.go
+++ b/internal/model/queue/queue.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 const (

--- a/internal/model/setting/setting.go
+++ b/internal/model/setting/setting.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import (

--- a/internal/model/setting/setting_dto.go
+++ b/internal/model/setting/setting_dto.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // SystemSettingDto 定义系统设置数据传输对象

--- a/internal/model/user/auth_identity.go
+++ b/internal/model/user/auth_identity.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import (

--- a/internal/model/user/user.go
+++ b/internal/model/user/user.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import (

--- a/internal/model/user/user_dto.go
+++ b/internal/model/user/user_dto.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 // UserInfoDto 用户信息数据传输对象

--- a/internal/model/visitor/visitor.go
+++ b/internal/model/visitor/visitor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package visitor
 
 // DailyStat 保存 PV/UV 的日粒度快照。

--- a/internal/model/webhook/webhook.go
+++ b/internal/model/webhook/webhook.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package model
 
 import (

--- a/internal/repository/auth/auth.go
+++ b/internal/repository/auth/auth.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/comment/comment.go
+++ b/internal/repository/comment/comment.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/common/common.go
+++ b/internal/repository/common/common.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/connect/connect.go
+++ b/internal/repository/connect/connect.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/echo/echo.go
+++ b/internal/repository/echo/echo.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/echo/echo_cache.go
+++ b/internal/repository/echo/echo_cache.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/echo/echo_cache_test.go
+++ b/internal/repository/echo/echo_cache_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/file/file.go
+++ b/internal/repository/file/file.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/init/init.go
+++ b/internal/repository/init/init.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/keyvalue/keyvalue.go
+++ b/internal/repository/keyvalue/keyvalue.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package keyvalue
 
 import (

--- a/internal/repository/keyvalue/keyvalue_cache.go
+++ b/internal/repository/keyvalue/keyvalue_cache.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package keyvalue
 
 const (

--- a/internal/repository/migration/migration.go
+++ b/internal/repository/migration/migration.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/provider.go
+++ b/internal/repository/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/queue/queue.go
+++ b/internal/repository/queue/queue.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/setting/setting.go
+++ b/internal/repository/setting/setting.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/user/user.go
+++ b/internal/repository/user/user.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/user/user_cache.go
+++ b/internal/repository/user/user_cache.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import "fmt"

--- a/internal/repository/visitor/visitor.go
+++ b/internal/repository/visitor/visitor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/repository/webhook/webhook.go
+++ b/internal/repository/webhook/webhook.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package repository
 
 import (

--- a/internal/router/agent.go
+++ b/internal/router/agent.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import "github.com/lin-snow/ech0/internal/handler"

--- a/internal/router/auth.go
+++ b/internal/router/auth.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/comment.go
+++ b/internal/router/comment.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/common.go
+++ b/internal/router/common.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/connect.go
+++ b/internal/router/connect.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/dashboard.go
+++ b/internal/router/dashboard.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/echo.go
+++ b/internal/router/echo.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/file.go
+++ b/internal/router/file.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/init.go
+++ b/internal/router/init.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import "github.com/lin-snow/ech0/internal/handler"

--- a/internal/router/mcp.go
+++ b/internal/router/mcp.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/middleware.go
+++ b/internal/router/middleware.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/migration.go
+++ b/internal/router/migration.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/modules.go
+++ b/internal/router/modules.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/resource.go
+++ b/internal/router/resource.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/setting.go
+++ b/internal/router/setting.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/template.go
+++ b/internal/router/template.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/router/user.go
+++ b/internal/router/user.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package router
 
 import (

--- a/internal/server/provider.go
+++ b/internal/server/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package server
 
 import (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // Package server
 //
 //	@title			Ech0 API 文档

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package server
 
 import (

--- a/internal/server/welcome.go
+++ b/internal/server/welcome.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package server
 
 import (
@@ -6,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	commonModel "github.com/lin-snow/ech0/internal/model/common"
+	versionPkg "github.com/lin-snow/ech0/internal/version"
 )
 
 const (
@@ -63,7 +66,7 @@ func PrintGreetings(port string) {
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
 		infoStyle.Render(
-			"📦 "+titleStyle.Render("Version")+": "+highlight.Render(commonModel.Version),
+			"📦 "+titleStyle.Render("Version")+": "+highlight.Render(versionPkg.Version),
 		),
 		infoStyle.Render("🎈 "+titleStyle.Render("Port")+": "+highlight.Render(port)),
 		infoStyle.Render("🧙 "+titleStyle.Render("Author")+": "+highlight.Render("L1nSn0w")),

--- a/internal/service/agent/agent.go
+++ b/internal/service/agent/agent.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/agent/ports.go
+++ b/internal/service/agent/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/auth/auth.go
+++ b/internal/service/auth/auth.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package auth
 
 import (

--- a/internal/service/auth/oauth_adapter.go
+++ b/internal/service/auth/oauth_adapter.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package auth
 
 import (

--- a/internal/service/auth/oauth_service_test.go
+++ b/internal/service/auth/oauth_service_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package auth
 
 import (

--- a/internal/service/auth/ports.go
+++ b/internal/service/auth/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package auth
 
 import (

--- a/internal/service/auth/provider.go
+++ b/internal/service/auth/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package auth
 
 import "github.com/google/wire"

--- a/internal/service/comment/comment.go
+++ b/internal/service/comment/comment.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/comment/comment_notify_test.go
+++ b/internal/service/comment/comment_notify_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import "testing"

--- a/internal/service/comment/mail_template.go
+++ b/internal/service/comment/mail_template.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/comment/mailer.go
+++ b/internal/service/comment/mailer.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/comment/mailer_test.go
+++ b/internal/service/comment/mailer_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/comment/ports.go
+++ b/internal/service/comment/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/common/common.go
+++ b/internal/service/common/common.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/common/ports.go
+++ b/internal/service/common/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/connect/connect.go
+++ b/internal/service/connect/connect.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (
@@ -15,6 +18,7 @@ import (
 	"github.com/lin-snow/ech0/internal/transaction"
 	httpUtil "github.com/lin-snow/ech0/internal/util/http"
 	logUtil "github.com/lin-snow/ech0/internal/util/log"
+	versionPkg "github.com/lin-snow/ech0/internal/version"
 	"github.com/lin-snow/ech0/pkg/viewer"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
@@ -161,7 +165,7 @@ func (connectService *ConnectService) GetConnect() (model.Connect, error) {
 	connect.TotalEchos = int(totalEchos)
 	connect.TodayEchos = len(todayEchos)
 	connect.SysUsername = owner.Username
-	connect.Version = commonModel.Version
+	connect.Version = versionPkg.Version
 
 	trimmedServerURL := strings.TrimRight(setting.ServerURL, "/")
 	logoPath := strings.TrimSpace(setting.ServerLogo)

--- a/internal/service/connect/connect_timezone_test.go
+++ b/internal/service/connect/connect_timezone_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/connect/ports.go
+++ b/internal/service/connect/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/dashboard/dashboard.go
+++ b/internal/service/dashboard/dashboard.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/dashboard/ports.go
+++ b/internal/service/dashboard/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/echo/echo.go
+++ b/internal/service/echo/echo.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/echo/echo_test.go
+++ b/internal/service/echo/echo_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/echo/ports.go
+++ b/internal/service/echo/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/file/file.go
+++ b/internal/service/file/file.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/file/ports.go
+++ b/internal/service/file/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/init/init.go
+++ b/internal/service/init/init.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/init/ports.go
+++ b/internal/service/init/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/migrator/migrator.go
+++ b/internal/service/migrator/migrator.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/migrator/migrator_test.go
+++ b/internal/service/migrator/migrator_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/migrator/ports.go
+++ b/internal/service/migrator/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/provider.go
+++ b/internal/service/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/access_token_service.go
+++ b/internal/service/setting/access_token_service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/access_token_service_test.go
+++ b/internal/service/setting/access_token_service_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/agent_setting_service.go
+++ b/internal/service/setting/agent_setting_service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/backup_schedule_service.go
+++ b/internal/service/setting/backup_schedule_service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/oauth2_setting_service.go
+++ b/internal/service/setting/oauth2_setting_service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/passkey_setting_service.go
+++ b/internal/service/setting/passkey_setting_service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/ports.go
+++ b/internal/service/setting/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/s3_setting_service.go
+++ b/internal/service/setting/s3_setting_service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/setting.go
+++ b/internal/service/setting/setting.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/system_setting_service.go
+++ b/internal/service/setting/system_setting_service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/setting/webhook_setting_service.go
+++ b/internal/service/setting/webhook_setting_service.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/user/ports.go
+++ b/internal/service/user/ports.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/service/user/user.go
+++ b/internal/service/user/user.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package service
 
 import (

--- a/internal/storage/keygen.go
+++ b/internal/storage/keygen.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package storage
 
 import (

--- a/internal/storage/manager.go
+++ b/internal/storage/manager.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package storage
 
 import (

--- a/internal/storage/manager_test.go
+++ b/internal/storage/manager_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package storage
 
 import (

--- a/internal/storage/provider.go
+++ b/internal/storage/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package storage
 
 import (

--- a/internal/storage/schema.go
+++ b/internal/storage/schema.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package storage
 
 import virefs "github.com/lin-snow/VireFS"

--- a/internal/storage/selector.go
+++ b/internal/storage/selector.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package storage
 
 import (

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package storage
 
 import "strings"

--- a/internal/task/provider.go
+++ b/internal/task/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package task
 
 import "github.com/google/wire"

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // package task declaration to use task related functionalities
 package task
 

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package task
 
 import (

--- a/internal/transaction/context.go
+++ b/internal/transaction/context.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package transaction
 
 import (

--- a/internal/transaction/gorm.go
+++ b/internal/transaction/gorm.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package transaction
 
 import (

--- a/internal/transaction/provider.go
+++ b/internal/transaction/provider.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package transaction
 
 import "github.com/google/wire"

--- a/internal/transaction/transaction.go
+++ b/internal/transaction/transaction.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package transaction
 
 import (

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package tui
 
 import (
@@ -8,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
-	commonModel "github.com/lin-snow/ech0/internal/model/common"
+	versionPkg "github.com/lin-snow/ech0/internal/version"
 )
 
 var (
@@ -150,7 +153,7 @@ func GetEch0Info() string {
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
 		infoStyle.Render(
-			"📦 "+titleStyle.Render("Version")+": "+highlight.Render(commonModel.Version),
+			"📦 "+titleStyle.Render("Version")+": "+highlight.Render(versionPkg.Version),
 		),
 		infoStyle.Render("🧙 "+titleStyle.Render("Author")+": "+highlight.Render("L1nSn0w")),
 		infoStyle.Render(

--- a/internal/util/cookie/cookie.go
+++ b/internal/util/cookie/cookie.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // Package cookie 提供 refresh token 的 HttpOnly Cookie 读写工具。
 //
 // Cookie 安全策略：

--- a/internal/util/crypto/crypto.go
+++ b/internal/util/crypto/crypto.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/err/err.go
+++ b/internal/util/err/err.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/format/format.go
+++ b/internal/util/format/format.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/github/github.go
+++ b/internal/util/github/github.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (
@@ -103,7 +106,7 @@ pageLoop:
 		return "", fmt.Errorf("no stable application release found (ech0-* chart tags are ignored)")
 	}
 
-	// 保持与 commonModel.Version 一致：返回不带 v 的 X.Y.Z
+	// 保持与 versionPkg.Version 一致：返回不带 v 的 X.Y.Z
 	result := strings.TrimPrefix(best, "v")
 
 	latestVersionCache.mu.Lock()

--- a/internal/util/github/github_test.go
+++ b/internal/util/github/github_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import "testing"

--- a/internal/util/http/http.go
+++ b/internal/util/http/http.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/http/http_security_test.go
+++ b/internal/util/http/http_security_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/img/img.go
+++ b/internal/util/img/img.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/jwt/jwt.go
+++ b/internal/util/jwt/jwt.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/jwt/jwt_test.go
+++ b/internal/util/jwt/jwt_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/log/log.go
+++ b/internal/util/log/log.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/md/md.go
+++ b/internal/util/md/md.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import (

--- a/internal/util/timezone/timezone.go
+++ b/internal/util/timezone/timezone.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package util
 
 import "time"

--- a/internal/util/uuid/uuid.go
+++ b/internal/util/uuid/uuid.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package uuid
 
 import (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
+// Package version is the single source of truth for build / release metadata
+// of the Ech0 binary: semantic version, git commit, build time, license,
+// author, repository URL.
+//
+// Const values are source-controlled (bump in code on release).
+// Var values are injected at build time via -ldflags "-X .../version.Commit=...".
+// See Makefile / docker/build.Dockerfile / .github/workflows/release.yml.
+package version
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// Version is the current semantic version. Bump on release.
+	Version = "4.6.4"
+
+	// License is the SPDX identifier of the project license.
+	License = "AGPL-3.0-or-later"
+
+	// Author is the primary author / copyright holder.
+	Author = "lin-snow"
+
+	// RepoURL is the canonical source repository URL. AGPL-3.0 §13 requires
+	// network users be able to obtain the corresponding source — this URL
+	// (combined with Commit) is what the About page surfaces to satisfy that.
+	RepoURL = "https://github.com/lin-snow/Ech0"
+
+	// StartYear is the project inception year, used to render copyright ranges.
+	// 首个公开 commit 是 2025-03-21；以此为版权起始年。
+	StartYear = 2025
+)
+
+// Commit is the short git commit hash, injected at build time.
+// Defaults to "unknown" so `go run` / unbranded local builds still compile.
+var Commit = "unknown"
+
+// BuildTime is the RFC3339 build timestamp, injected at build time.
+// Empty when not injected.
+var BuildTime = ""
+
+// Info bundles all build / release metadata. Useful for handlers that want
+// to return a single struct instead of hand-spelling every field.
+type Info struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildTime string `json:"build_time"`
+	License   string `json:"license"`
+	Author    string `json:"author"`
+	RepoURL   string `json:"repo_url"`
+}
+
+// Get returns a snapshot of the current build / release metadata.
+func Get() Info {
+	return Info{
+		Version:   Version,
+		Commit:    Commit,
+		BuildTime: BuildTime,
+		License:   License,
+		Author:    Author,
+		RepoURL:   RepoURL,
+	}
+}
+
+// Copyright returns the human-readable copyright line, e.g.
+// "Copyright (C) 2025-2026 lin-snow".
+// The end year is the current UTC year, or StartYear if the clock is broken.
+func Copyright() string {
+	end := time.Now().UTC().Year()
+	if end <= StartYear {
+		return fmt.Sprintf("Copyright (C) %d %s", StartYear, Author)
+	}
+	return fmt.Sprintf("Copyright (C) %d-%d %s", StartYear, end, Author)
+}

--- a/internal/visitor/visitor.go
+++ b/internal/visitor/visitor.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // Package visitor 实现进程内的 PV/UV 统计。
 //
 // 设计要点:

--- a/internal/visitor/visitor_test.go
+++ b/internal/visitor/visitor_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package visitor
 
 import (

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package webhook
 
 import (

--- a/internal/webhook/infra/httpclient/client.go
+++ b/internal/webhook/infra/httpclient/client.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package httpclient
 
 import (

--- a/internal/webhook/infra/httpclient/safe_client.go
+++ b/internal/webhook/infra/httpclient/safe_client.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package httpclient
 
 import (

--- a/internal/webhook/infra/httpclient/safe_client_test.go
+++ b/internal/webhook/infra/httpclient/safe_client_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package httpclient
 
 import (

--- a/pkg/viewer/context.go
+++ b/pkg/viewer/context.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package viewer
 
 import (

--- a/pkg/viewer/context_test.go
+++ b/pkg/viewer/context_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package viewer
 
 import (

--- a/pkg/viewer/noop.go
+++ b/pkg/viewer/noop.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package viewer
 
 type NoopViewer struct{}

--- a/pkg/viewer/system.go
+++ b/pkg/viewer/system.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package viewer
 
 // NewSystemViewer returns a system-scoped viewer.

--- a/pkg/viewer/user.go
+++ b/pkg/viewer/user.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 package viewer
 
 type UserViewer struct {

--- a/pkg/viewer/viewer.go
+++ b/pkg/viewer/viewer.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // Package viewer provides a unified viewer context abstraction.
 package viewer
 

--- a/scripts/add-spdx-headers.mjs
+++ b/scripts/add-spdx-headers.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+//
+// Idempotent batch tool: prepend SPDX-License-Identifier + Copyright headers to
+// every .go / .ts / .vue source file in this repo. Re-running is safe — files
+// already containing "SPDX-License-Identifier" are skipped.
+//
+// Usage:
+//   node scripts/add-spdx-headers.mjs           # write
+//   node scripts/add-spdx-headers.mjs --check   # exit 1 if any file is missing a header (CI)
+//   node scripts/add-spdx-headers.mjs --dry-run # report what would change, write nothing
+
+import { readdir, readFile, writeFile, stat } from 'node:fs/promises'
+import { join, relative, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const SPDX_ID = 'SPDX-License-Identifier: AGPL-3.0-or-later'
+const COPYRIGHT = 'Copyright (C) 2025-2026 lin-snow'
+
+const SKIP_DIRS = new Set([
+  '.git',
+  '.github',
+  '.claude',
+  '.pnpm-store',
+  '.worktrees',
+  '.vscode',
+  '.idea',
+  '.cache',
+  'node_modules',
+  'data',
+  'backup',
+  'tmp',
+  'bin',
+  'release',
+  'dist',
+])
+
+// Files explicitly excluded — generated, vendored, or upstream-owned.
+const SKIP_FILES = new Set([
+  'internal/di/wire_gen.go',
+  'web/src/components/icons',
+])
+
+const SKIP_PATH_FRAGMENTS = [
+  'internal/swagger/',
+  'template/dist/',
+  'web/dist/',
+  'web/src/components/icons/', // SVG icons embed their own source/license attribution
+]
+
+const EXTS = new Set(['.go', '.ts', '.vue'])
+
+const args = process.argv.slice(2)
+const MODE = args.includes('--check') ? 'check' : args.includes('--dry-run') ? 'dry' : 'write'
+
+async function* walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true })
+  for (const e of entries) {
+    const full = join(dir, e.name)
+    if (e.isDirectory()) {
+      if (SKIP_DIRS.has(e.name)) continue
+      yield* walk(full)
+    } else if (e.isFile()) {
+      const rel = relative(REPO_ROOT, full)
+      if (SKIP_PATH_FRAGMENTS.some((f) => rel.includes(f))) continue
+      if (SKIP_FILES.has(rel)) continue
+      const dot = full.lastIndexOf('.')
+      if (dot === -1) continue
+      const ext = full.slice(dot)
+      if (!EXTS.has(ext)) continue
+      yield { full, rel, ext }
+    }
+  }
+}
+
+function insertGo(src) {
+  // Respect //go:build constraints — they must remain the first non-blank line.
+  const lines = src.split('\n')
+  let insertAt = 0
+  if (lines[0]?.startsWith('//go:build') || lines[0]?.startsWith('// +build')) {
+    // Build tag block ends at the first blank line; insert AFTER it.
+    let i = 0
+    while (i < lines.length && lines[i].trim() !== '') i++
+    insertAt = i + 1
+  }
+  const header = ['// ' + SPDX_ID, '// ' + COPYRIGHT, '']
+  return [...lines.slice(0, insertAt), ...header, ...lines.slice(insertAt)].join('\n')
+}
+
+function insertTs(src) {
+  // Preserve shebang as the first line.
+  if (src.startsWith('#!')) {
+    const nl = src.indexOf('\n')
+    const head = src.slice(0, nl + 1)
+    const tail = src.slice(nl + 1)
+    return head + `// ${SPDX_ID}\n// ${COPYRIGHT}\n\n` + tail
+  }
+  return `// ${SPDX_ID}\n// ${COPYRIGHT}\n\n` + src
+}
+
+function insertVue(src) {
+  return `<!-- ${SPDX_ID} -->\n<!-- ${COPYRIGHT} -->\n` + src
+}
+
+async function processFile({ full, rel, ext }) {
+  const src = await readFile(full, 'utf8')
+  if (src.includes('SPDX-License-Identifier')) return { rel, status: 'skip' }
+  let next
+  if (ext === '.go') next = insertGo(src)
+  else if (ext === '.ts') next = insertTs(src)
+  else if (ext === '.vue') next = insertVue(src)
+  else return { rel, status: 'skip' }
+  if (MODE === 'check') return { rel, status: 'missing' }
+  if (MODE === 'dry') return { rel, status: 'would-write' }
+  await writeFile(full, next, 'utf8')
+  return { rel, status: 'wrote' }
+}
+
+async function main() {
+  const stats = { wrote: 0, skip: 0, missing: 0, 'would-write': 0 }
+  const missing = []
+  for await (const f of walk(REPO_ROOT)) {
+    const r = await processFile(f)
+    stats[r.status] = (stats[r.status] || 0) + 1
+    if (r.status === 'missing') missing.push(r.rel)
+  }
+  if (MODE === 'check') {
+    console.log(`Files already covered: ${stats.skip}`)
+    console.log(`Files missing header: ${stats.missing}`)
+    if (stats.missing > 0) {
+      console.log('\nMissing:')
+      for (const m of missing.slice(0, 50)) console.log('  ' + m)
+      if (missing.length > 50) console.log(`  ... and ${missing.length - 50} more`)
+      process.exit(1)
+    }
+    return
+  }
+  if (MODE === 'dry') {
+    console.log(`Would write headers to ${stats['would-write']} files; ${stats.skip} already covered.`)
+    return
+  }
+  console.log(`Wrote headers to ${stats.wrote} files; ${stats.skip} already covered.`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(2)
+})

--- a/site/app/docs/registry.ts
+++ b/site/app/docs/registry.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 const raw = import.meta.glob<string>("../../docs/**/*.md", {
   query: "?raw",
   import: "default",

--- a/site/app/docs/toc.ts
+++ b/site/app/docs/toc.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export type TocItem = {
   depth: 2 | 3;
   text: string;

--- a/site/app/routes.ts
+++ b/site/app/routes.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
 export default [

--- a/site/app/site.ts
+++ b/site/app/site.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /**
  * Canonical site origin for absolute URLs (OG, Twitter, JSON-LD).
  * Override with `VITE_SITE_URL` when deploying.

--- a/site/react-router.config.ts
+++ b/site/react-router.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { Config } from "@react-router/dev/config";
 
 export default {

--- a/site/vite-env.d.ts
+++ b/site/vite-env.d.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /// <reference types="vite/client" />
 
 declare module "*.md?raw" {

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
 import type { Plugin } from "vite";

--- a/template/template.go
+++ b/template/template.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2024-2026 lin-snow
+
 package template
 
 import "embed"

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -1,1 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /// <reference types="vite/client" />

--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { globalIgnores } from 'eslint/config'
 import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
 import pluginVue from 'eslint-plugin-vue'

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,9 @@
   "name": "web",
   "version": "1.0.0",
   "private": true,
+  "license": "AGPL-3.0-or-later",
+  "author": "lin-snow",
+  "homepage": "https://github.com/lin-snow/Ech0",
   "type": "module",
   "engines": {
     "node": ">=25.9.0"

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import { RouterView, useRouter } from 'vue-router'
 import { computed, onMounted, ref, watch } from 'vue'

--- a/web/src/components/advanced/TheBackTop.vue
+++ b/web/src/components/advanced/TheBackTop.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <button
     @click="scrollToTop"

--- a/web/src/components/advanced/TheComment.vue
+++ b/web/src/components/advanced/TheComment.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div id="comments" class="w-full max-w-sm h-auto px-0 py-4 my-4 mx-auto">
     <div

--- a/web/src/components/advanced/TheUploader.vue
+++ b/web/src/components/advanced/TheUploader.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="rounded-md overflow-hidden">
     <!-- Drop zone (also click-to-pick) -->

--- a/web/src/components/advanced/echo/cards/TheEchoCard.vue
+++ b/web/src/components/advanced/echo/cards/TheEchoCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="echo-timeline w-full">
     <div class="echo-header-sticky flex justify-between items-center">

--- a/web/src/components/advanced/echo/cards/TheEchoDetail.vue
+++ b/web/src/components/advanced/echo/cards/TheEchoDetail.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full max-w-sm bg-[var(--color-bg-surface)] h-auto p-5 shadow rounded-md mx-auto">
     <div class="flex flex-row items-center gap-2 mt-2 mb-4">

--- a/web/src/components/advanced/echo/cards/TheHubEcho.vue
+++ b/web/src/components/advanced/echo/cards/TheHubEcho.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="w-full max-w-sm bg-[var(--color-bg-surface)] h-auto p-3.5 sm:p-4 shadow rounded-sm mx-auto"

--- a/web/src/components/advanced/echo/cards/TheShareEchoPanel.vue
+++ b/web/src/components/advanced/echo/cards/TheShareEchoPanel.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <Popover class="relative flex items-center">
     <PopoverButton

--- a/web/src/components/advanced/extension/TheExtensionRenderer.vue
+++ b/web/src/components/advanced/extension/TheExtensionRenderer.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div v-if="echo.extension" class="extension-renderer">
     <APlayerCard v-if="echo.extension.type === ExtensionType.MUSIC" :echo="echo" />

--- a/web/src/components/advanced/extension/cards/APlayerCard.vue
+++ b/web/src/components/advanced/extension/cards/APlayerCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <ExtensionCardShell
     v-if="

--- a/web/src/components/advanced/extension/cards/GithubCard.vue
+++ b/web/src/components/advanced/extension/cards/GithubCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <ExtensionCardShell v-if="safeGithubURL" :header-label="t('extensionCard.github')">
     <template #header-icon><Githubproj /></template>

--- a/web/src/components/advanced/extension/cards/LocationCard.vue
+++ b/web/src/components/advanced/extension/cards/LocationCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <ExtensionCardShell :header-label="t('extensionCard.location')">
     <template #header-icon><MapPin /></template>

--- a/web/src/components/advanced/extension/cards/VideoCard.vue
+++ b/web/src/components/advanced/extension/cards/VideoCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <ExtensionCardShell :header-label="providerLabel">
     <template #header-icon><Video /></template>

--- a/web/src/components/advanced/extension/cards/WebsiteCard.vue
+++ b/web/src/components/advanced/extension/cards/WebsiteCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <ExtensionCardShell :header-label="t('extensionCard.website')">
     <template #header-icon><Link /></template>

--- a/web/src/components/advanced/extension/shared/ExtensionCardShell.vue
+++ b/web/src/components/advanced/extension/shared/ExtensionCardShell.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="extension-card-shell" :class="[sizeClass, paddingClass]">
     <div v-if="hasHeader" class="extension-card-shell__header">

--- a/web/src/components/advanced/extension/shared/ExtensionCardSkeleton.vue
+++ b/web/src/components/advanced/extension/shared/ExtensionCardSkeleton.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="extension-skeleton" :style="styleVars" aria-hidden="true">
     <div class="skeleton-line w-16"></div>

--- a/web/src/components/advanced/extension/shared/LocationPicker.vue
+++ b/web/src/components/advanced/extension/shared/LocationPicker.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="location-picker"

--- a/web/src/components/advanced/extension/shared/useReverseGeocoding.ts
+++ b/web/src/components/advanced/extension/shared/useReverseGeocoding.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { ref, watch, type Ref } from 'vue'
 
 const NOMINATIM_ENDPOINT = 'https://nominatim.openstreetmap.org/reverse'

--- a/web/src/components/advanced/gallery/TheImageGallery.vue
+++ b/web/src/components/advanced/gallery/TheImageGallery.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div v-if="images.length" class="image-gallery-container">
     <GalleryWaterfall

--- a/web/src/components/advanced/gallery/composables/usePhotoSwipeGallery.ts
+++ b/web/src/components/advanced/gallery/composables/usePhotoSwipeGallery.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { onBeforeUnmount, shallowRef, type Ref } from 'vue'
 import PhotoSwipe from 'photoswipe'
 import 'photoswipe/style.css'

--- a/web/src/components/advanced/gallery/layouts/GalleryCarousel.vue
+++ b/web/src/components/advanced/gallery/layouts/GalleryCarousel.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-[88%] mx-auto mb-4">
     <div class="carousel-container rounded-lg overflow-hidden">

--- a/web/src/components/advanced/gallery/layouts/GalleryGrid.vue
+++ b/web/src/components/advanced/gallery/layouts/GalleryGrid.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-[88%] mx-auto mb-4">
     <div class="grid grid-cols-3 gap-2">

--- a/web/src/components/advanced/gallery/layouts/GalleryHorizontal.vue
+++ b/web/src/components/advanced/gallery/layouts/GalleryHorizontal.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-[88%] mx-auto mb-4">
     <div class="horizontal-scroll-container">

--- a/web/src/components/advanced/gallery/layouts/GalleryStack.vue
+++ b/web/src/components/advanced/gallery/layouts/GalleryStack.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="stack-root">
     <div class="stack-scroll">

--- a/web/src/components/advanced/gallery/layouts/GalleryWaterfall.vue
+++ b/web/src/components/advanced/gallery/layouts/GalleryWaterfall.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     :class="[

--- a/web/src/components/advanced/gallery/layouts/types.ts
+++ b/web/src/components/advanced/gallery/layouts/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export type GalleryOpenHandler = (startIndex: number, sourceElement?: HTMLElement | null) => void
 
 export type GalleryImageHelperProps = {

--- a/web/src/components/advanced/gallery/parts/GalleryImageItem.vue
+++ b/web/src/components/advanced/gallery/parts/GalleryImageItem.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <button
     class="bg-transparent border-0 p-0 cursor-pointer"

--- a/web/src/components/advanced/md/TheMdEditor.vue
+++ b/web/src/components/advanced/md/TheMdEditor.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <MarkdownEditor class="h-auto" v-model="content" :placeholder="t('editor.mainPlaceholder')" />
 </template>

--- a/web/src/components/advanced/md/TheMdPreview.vue
+++ b/web/src/components/advanced/md/TheMdPreview.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <MarkdownRenderer :content="props.content" />
 </template>

--- a/web/src/components/advanced/md/index.ts
+++ b/web/src/components/advanced/md/index.ts
@@ -1,2 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export { default as TheMdEditor } from './TheMdEditor.vue'
 export { default as TheMdPreview } from './TheMdPreview.vue'

--- a/web/src/components/advanced/widget/TheActivityLog.vue
+++ b/web/src/components/advanced/widget/TheActivityLog.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="activity-log p-1">
     <div class="activity-head">

--- a/web/src/components/advanced/widget/TheCommentWidget.vue
+++ b/web/src/components/advanced/widget/TheCommentWidget.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="px-2">
     <div class="widget bg-transparent! w-full max-w-[19rem] mx-auto rounded-md p-4">

--- a/web/src/components/advanced/widget/TheConnectWidget.vue
+++ b/web/src/components/advanced/widget/TheConnectWidget.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="px-2">
     <div class="widget bg-transparent! w-full max-w-[19rem] mx-auto rounded-md p-4">

--- a/web/src/components/advanced/widget/TheHeatMap.vue
+++ b/web/src/components/advanced/widget/TheHeatMap.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="px-2">
     <div class="widget bg-transparent! w-full max-w-[19rem] mx-auto rounded-md p-4">

--- a/web/src/components/advanced/widget/TheRecentCard.vue
+++ b/web/src/components/advanced/widget/TheRecentCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div v-if="AgentSetting.enable" class="px-2">
     <div class="widget bg-transparent! w-full max-w-[19rem] mx-auto rounded-md p-4">

--- a/web/src/components/advanced/widget/TheTagPileWidget.vue
+++ b/web/src/components/advanced/widget/TheTagPileWidget.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="px-2">
     <div class="widget bg-transparent! w-full max-w-[19rem] mx-auto rounded-md p-1">

--- a/web/src/components/advanced/widget/TheVisitorStatsWidget.vue
+++ b/web/src/components/advanced/widget/TheVisitorStatsWidget.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="visitor-widget p-1">
     <div class="visitor-head">

--- a/web/src/components/advanced/widget/index.ts
+++ b/web/src/components/advanced/widget/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export { default as TheConnectWidget } from './TheConnectWidget.vue'
 export { default as TheCommentWidget } from './TheCommentWidget.vue'
 export { default as TheHeatMap } from './TheHeatMap.vue'

--- a/web/src/components/common/BaseAvatar.vue
+++ b/web/src/components/common/BaseAvatar.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <img :src="avatarSrc" :alt="alt" decoding="async" />
 </template>

--- a/web/src/components/common/BaseButton.vue
+++ b/web/src/components/common/BaseButton.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <BaseTooltip :content="effectiveTooltip">
     <button

--- a/web/src/components/common/BaseCombobox.vue
+++ b/web/src/components/common/BaseCombobox.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="base-combobox">
     <!-- Label -->

--- a/web/src/components/common/BaseDialog.vue
+++ b/web/src/components/common/BaseDialog.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <!-- ConfirmDialog.vue -->
 <template>
   <TransitionRoot :show="isOpen" as="template">

--- a/web/src/components/common/BaseEditCapsule.vue
+++ b/web/src/components/common/BaseEditCapsule.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="inline-flex items-center rounded-full ring-1 ring-inset ring-[var(--color-border-subtle)] bg-[var(--input-bg-color)] overflow-hidden"

--- a/web/src/components/common/BaseInput.vue
+++ b/web/src/components/common/BaseInput.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="base-input w-full">
     <!-- Label -->

--- a/web/src/components/common/BaseModal.vue
+++ b/web/src/components/common/BaseModal.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <TransitionRoot appear :show="modelValue" as="template">
     <Dialog as="div" @close="closeModal" class="relative z-50">

--- a/web/src/components/common/BaseSelect.vue
+++ b/web/src/components/common/BaseSelect.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="base-select" ref="selectRef">
     <!-- Label -->

--- a/web/src/components/common/BaseSwitch.vue
+++ b/web/src/components/common/BaseSwitch.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <button
     type="button"

--- a/web/src/components/common/BaseTextArea.vue
+++ b/web/src/components/common/BaseTextArea.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="base-textarea w-full">
     <!-- Label -->

--- a/web/src/components/common/BaseTooltip.vue
+++ b/web/src/components/common/BaseTooltip.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <slot v-if="isDisabled" />
   <VTooltip v-else :placement="placementValue" :delay="delay" :distance="distance" :theme="theme">

--- a/web/src/components/common/TheLoadingIndicator.vue
+++ b/web/src/components/common/TheLoadingIndicator.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="loading-indicator"

--- a/web/src/components/common/TheRouteProgress.vue
+++ b/web/src/components/common/TheRouteProgress.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="route-progress"

--- a/web/src/composables/useBaseDialog.ts
+++ b/web/src/composables/useBaseDialog.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { ref, shallowRef, nextTick } from 'vue'
 
 const title = ref('')

--- a/web/src/composables/useBfCacheRestore.ts
+++ b/web/src/composables/useBfCacheRestore.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 
 type UseBfCacheRestoreOptions = {

--- a/web/src/composables/useSeoHead.ts
+++ b/web/src/composables/useSeoHead.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { Ref } from 'vue'
 import { watch } from 'vue'
 import { useRoute } from 'vue-router'

--- a/web/src/constants/file.ts
+++ b/web/src/constants/file.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export const FILE_CATEGORY = {
   IMAGE: 'image',
   AUDIO: 'audio',

--- a/web/src/editor/components/MarkdownEditor.vue
+++ b/web/src/editor/components/MarkdownEditor.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="markdown-editor-root">
     <div v-if="isFullMode" class="markdown-editor-backdrop" @click="exitFullMode"></div>

--- a/web/src/editor/components/MarkdownPreviewCard.vue
+++ b/web/src/editor/components/MarkdownPreviewCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <article class="markdown-preview-card" :class="{ 'is-long-content': isLongContent }">
     <header class="preview-card-header">{{ t('editor.preview') }}</header>

--- a/web/src/editor/components/MarkdownRenderer.vue
+++ b/web/src/editor/components/MarkdownRenderer.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div ref="rootRef" class="echo-markdown">
     <!-- markdown chunk 还没到时直接显示原文，比一个会呼吸的灰条更有信息量；

--- a/web/src/editor/composables/useMarkdownEditorActions.ts
+++ b/web/src/editor/composables/useMarkdownEditorActions.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { MarkdownEditorAction } from '../types'
 
 function ensureSelection(

--- a/web/src/editor/core/markdown-highlight.ts
+++ b/web/src/editor/core/markdown-highlight.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import hljs from 'highlight.js/lib/core'
 import bash from 'highlight.js/lib/languages/bash'
 import css from 'highlight.js/lib/languages/css'

--- a/web/src/editor/core/markdown.ts
+++ b/web/src/editor/core/markdown.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import MarkdownIt from 'markdown-it'
 
 type HighlightJsModule = (typeof import('./markdown-highlight'))['default']

--- a/web/src/editor/index.ts
+++ b/web/src/editor/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import './styles/editor.scss'
 
 export { default as MarkdownEditor } from './components/MarkdownEditor.vue'

--- a/web/src/editor/preview.ts
+++ b/web/src/editor/preview.ts
@@ -1,1 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export { default as MarkdownRenderer } from './components/MarkdownRenderer.vue'

--- a/web/src/editor/types/index.ts
+++ b/web/src/editor/types/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export type MarkdownEditorAction =
   | 'bold'
   | 'italic'

--- a/web/src/enums/enums.ts
+++ b/web/src/enums/enums.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // 编辑器的状态
 export enum Mode {
   ECH0 = 0, // 默认编辑状态

--- a/web/src/global.d.ts
+++ b/web/src/global.d.ts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+

--- a/web/src/layout/MetricCard.vue
+++ b/web/src/layout/MetricCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="border border-[var(--color-border-strong)] border-dashed rounded-md text-nowrap overflow-auto"

--- a/web/src/layout/PanelCard.vue
+++ b/web/src/layout/PanelCard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="panel-card rounded-[var(--radius-lg)] p-4 border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] shadow-[var(--shadow-sm)] overflow-auto"

--- a/web/src/lib/file/api/adapter.ts
+++ b/web/src/lib/file/api/adapter.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { FILE_STORAGE_TYPE } from '@/constants/file'
 import {
   fetchCreateExternalFile,

--- a/web/src/lib/file/attachments/attachment-manager.ts
+++ b/web/src/lib/file/attachments/attachment-manager.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { FileAttachment, FileValidationRule } from '../types'
 
 function keyOf(file: FileAttachment): string {

--- a/web/src/lib/file/compress.ts
+++ b/web/src/lib/file/compress.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { isSafari } from '@/utils/other'
 
 const DEFAULT_CONVERT_SIZE = 5 * 1024 * 1024

--- a/web/src/lib/file/hooks/useFileAttachments.ts
+++ b/web/src/lib/file/hooks/useFileAttachments.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { computed, ref } from 'vue'
 import { AttachmentManager } from '../attachments/attachment-manager'
 import type { FileAttachment, FileValidationRule } from '../types'

--- a/web/src/lib/file/hooks/useFileQueue.ts
+++ b/web/src/lib/file/hooks/useFileQueue.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { computed } from 'vue'
 import { FileQueue, globalFileQueue } from '../queue/file-queue'
 import type { FileUploadInput, QueueTask } from '../types'

--- a/web/src/lib/file/index.ts
+++ b/web/src/lib/file/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export * from './types'
 export * from './api/adapter'
 export * from './queue/file-queue'

--- a/web/src/lib/file/queue/file-queue.ts
+++ b/web/src/lib/file/queue/file-queue.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { ref } from 'vue'
 import { fileApiAdapter } from '../api/adapter'
 import type { FileApiAdapter } from '../api/adapter'

--- a/web/src/lib/file/registry/file-registry.ts
+++ b/web/src/lib/file/registry/file-registry.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { FileCategory, FileEntity } from '../types'
 
 export class FileRegistry {

--- a/web/src/lib/file/selectors/file-selectors.ts
+++ b/web/src/lib/file/selectors/file-selectors.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 type DedupeKey = 'id' | 'key' | 'url'
 
 export type FileSelectorOptions<T extends { category?: unknown; storage_type?: unknown }> = {

--- a/web/src/lib/file/types.ts
+++ b/web/src/lib/file/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { FILE_CATEGORY, FILE_STORAGE_TYPE } from '@/constants/file'
 
 export type FileCategory = (typeof FILE_CATEGORY)[keyof typeof FILE_CATEGORY]

--- a/web/src/lib/file/upload.ts
+++ b/web/src/lib/file/upload.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export const UPLOAD_KIND = {
   LOCAL: 'local',
   S3: 's3',

--- a/web/src/lib/file/useUpload.ts
+++ b/web/src/lib/file/useUpload.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { computed, type Ref, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { FILE_CATEGORY, FILE_STORAGE_TYPE } from '@/constants/file'

--- a/web/src/locales/index.ts
+++ b/web/src/locales/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { createI18n } from 'vue-i18n'
 import { localStg } from '@/utils/storage'
 

--- a/web/src/locales/messages/de-DE.json
+++ b/web/src/locales/messages/de-DE.json
@@ -906,6 +906,21 @@
   "commonNav": {
     "backHome": "Zurück zur Startseite"
   },
+  "about": {
+    "linkAriaLabel": "Über diese Ech0-Instanz",
+    "tagline": "Eine selbst gehostete, leichtgewichtige Publishing-Plattform für deine Gedanken.",
+    "copyrightHeading": "Urheberrecht",
+    "copyrightLine": "Copyright (C) {year} {holder}. Alle Rechte vorbehalten.",
+    "licenseLine": "Veröffentlicht unter der",
+    "agplNotice": "Als Netzwerkdienst folgt Ech0 der AGPL-3.0 §13: Nutzer, die mit dieser Instanz interagieren, haben Anspruch auf den entsprechenden Quellcode.",
+    "authorHeading": "Autor",
+    "authorGithub": "GitHub-Profil",
+    "sourceHeading": "Quellcode",
+    "sourceDescription": "Der vollständige Quellcode von Ech0 ist auf GitHub öffentlich verfügbar.",
+    "viewSource": "Quellcode auf GitHub ansehen",
+    "viewRelease": "Release-Notes für v{version}",
+    "poweredBy": "Mit Sorgfalt gebaut · Powered by Ech0"
+  },
   "echoPage": {
     "loadingDetail": "Echo-Details werden geladen…"
   },

--- a/web/src/locales/messages/de-DE.json
+++ b/web/src/locales/messages/de-DE.json
@@ -910,7 +910,6 @@
     "linkAriaLabel": "Über diese Ech0-Instanz",
     "tagline": "Eine selbst gehostete, leichtgewichtige Publishing-Plattform für deine Gedanken.",
     "copyrightHeading": "Urheberrecht",
-    "copyrightLine": "Copyright (C) {year} {holder}. Alle Rechte vorbehalten.",
     "licenseLine": "Veröffentlicht unter der",
     "agplNotice": "Als Netzwerkdienst folgt Ech0 der AGPL-3.0 §13: Nutzer, die mit dieser Instanz interagieren, haben Anspruch auf den entsprechenden Quellcode.",
     "authorHeading": "Autor",
@@ -918,7 +917,9 @@
     "sourceHeading": "Quellcode",
     "sourceDescription": "Der vollständige Quellcode von Ech0 ist auf GitHub öffentlich verfügbar.",
     "viewSource": "Quellcode auf GitHub ansehen",
+    "viewSourceAtCommit": "Quellcode @ {commit} auf GitHub ansehen",
     "viewRelease": "Release-Notes für v{version}",
+    "buildTime": "Gebaut am {time}",
     "poweredBy": "Mit Sorgfalt gebaut · Powered by Ech0"
   },
   "echoPage": {

--- a/web/src/locales/messages/en-US.json
+++ b/web/src/locales/messages/en-US.json
@@ -906,6 +906,21 @@
   "commonNav": {
     "backHome": "Back to home"
   },
+  "about": {
+    "linkAriaLabel": "About this Ech0 instance",
+    "tagline": "A self-hosted, lightweight publishing platform for your thoughts.",
+    "copyrightHeading": "Copyright",
+    "copyrightLine": "Copyright (C) {year} {holder}. All rights reserved.",
+    "licenseLine": "Released under the",
+    "agplNotice": "As a network service, Ech0 follows AGPL-3.0 §13: users interacting with this instance are entitled to receive its corresponding source code.",
+    "authorHeading": "Author",
+    "authorGithub": "GitHub Profile",
+    "sourceHeading": "Source Code",
+    "sourceDescription": "The full source code of Ech0 is publicly available on GitHub.",
+    "viewSource": "View source on GitHub",
+    "viewRelease": "Release notes for v{version}",
+    "poweredBy": "Built with care · Powered by Ech0"
+  },
   "echoPage": {
     "loadingDetail": "Loading Echo details..."
   },

--- a/web/src/locales/messages/en-US.json
+++ b/web/src/locales/messages/en-US.json
@@ -910,7 +910,6 @@
     "linkAriaLabel": "About this Ech0 instance",
     "tagline": "A self-hosted, lightweight publishing platform for your thoughts.",
     "copyrightHeading": "Copyright",
-    "copyrightLine": "Copyright (C) {year} {holder}. All rights reserved.",
     "licenseLine": "Released under the",
     "agplNotice": "As a network service, Ech0 follows AGPL-3.0 §13: users interacting with this instance are entitled to receive its corresponding source code.",
     "authorHeading": "Author",
@@ -918,7 +917,9 @@
     "sourceHeading": "Source Code",
     "sourceDescription": "The full source code of Ech0 is publicly available on GitHub.",
     "viewSource": "View source on GitHub",
+    "viewSourceAtCommit": "View source @ {commit} on GitHub",
     "viewRelease": "Release notes for v{version}",
+    "buildTime": "Built {time}",
     "poweredBy": "Built with care · Powered by Ech0"
   },
   "echoPage": {

--- a/web/src/locales/messages/ja-JP.json
+++ b/web/src/locales/messages/ja-JP.json
@@ -906,6 +906,21 @@
   "commonNav": {
     "backHome": "ホームに戻る"
   },
+  "about": {
+    "linkAriaLabel": "この Ech0 インスタンスについて",
+    "tagline": "セルフホスト型の軽量パブリッシングプラットフォーム。",
+    "copyrightHeading": "著作権",
+    "copyrightLine": "Copyright (C) {year} {holder}. All rights reserved.",
+    "licenseLine": "本ソフトウェアは",
+    "agplNotice": "ネットワークサービスとして、Ech0 は AGPL-3.0 第 13 条に従います：本インスタンスを利用するユーザーは、対応するソースコードを取得する権利を有します。",
+    "authorHeading": "作者",
+    "authorGithub": "GitHub プロフィール",
+    "sourceHeading": "ソースコード",
+    "sourceDescription": "Ech0 の完全なソースコードは GitHub で公開されています。",
+    "viewSource": "GitHub でソースを見る",
+    "viewRelease": "v{version} リリースノート",
+    "poweredBy": "心を込めて · Powered by Ech0"
+  },
   "echoPage": {
     "loadingDetail": "Echo の詳細を読み込み中..."
   },

--- a/web/src/locales/messages/ja-JP.json
+++ b/web/src/locales/messages/ja-JP.json
@@ -910,7 +910,6 @@
     "linkAriaLabel": "この Ech0 インスタンスについて",
     "tagline": "セルフホスト型の軽量パブリッシングプラットフォーム。",
     "copyrightHeading": "著作権",
-    "copyrightLine": "Copyright (C) {year} {holder}. All rights reserved.",
     "licenseLine": "本ソフトウェアは",
     "agplNotice": "ネットワークサービスとして、Ech0 は AGPL-3.0 第 13 条に従います：本インスタンスを利用するユーザーは、対応するソースコードを取得する権利を有します。",
     "authorHeading": "作者",
@@ -918,7 +917,9 @@
     "sourceHeading": "ソースコード",
     "sourceDescription": "Ech0 の完全なソースコードは GitHub で公開されています。",
     "viewSource": "GitHub でソースを見る",
+    "viewSourceAtCommit": "GitHub で commit @ {commit} のソースを見る",
     "viewRelease": "v{version} リリースノート",
+    "buildTime": "ビルド時刻 {time}",
     "poweredBy": "心を込めて · Powered by Ech0"
   },
   "echoPage": {

--- a/web/src/locales/messages/zh-CN.json
+++ b/web/src/locales/messages/zh-CN.json
@@ -910,7 +910,6 @@
     "linkAriaLabel": "关于本 Ech0 实例",
     "tagline": "一个自托管的轻量级个人发布平台。",
     "copyrightHeading": "版权",
-    "copyrightLine": "Copyright (C) {year} {holder}. 保留所有权利。",
     "licenseLine": "本软件以",
     "agplNotice": "作为网络服务，Ech0 遵循 AGPL-3.0 第 13 条：与本实例交互的用户有权获取其对应版本的源代码。",
     "authorHeading": "作者",
@@ -918,7 +917,9 @@
     "sourceHeading": "源代码",
     "sourceDescription": "Ech0 的完整源代码在 GitHub 上公开可用。",
     "viewSource": "在 GitHub 上查看源代码",
+    "viewSourceAtCommit": "在 GitHub 上查看 commit @ {commit} 的源代码",
     "viewRelease": "v{version} 发布说明",
+    "buildTime": "构建时间 {time}",
     "poweredBy": "用心打造 · Powered by Ech0"
   },
   "echoPage": {

--- a/web/src/locales/messages/zh-CN.json
+++ b/web/src/locales/messages/zh-CN.json
@@ -906,6 +906,21 @@
   "commonNav": {
     "backHome": "返回首页"
   },
+  "about": {
+    "linkAriaLabel": "关于本 Ech0 实例",
+    "tagline": "一个自托管的轻量级个人发布平台。",
+    "copyrightHeading": "版权",
+    "copyrightLine": "Copyright (C) {year} {holder}. 保留所有权利。",
+    "licenseLine": "本软件以",
+    "agplNotice": "作为网络服务，Ech0 遵循 AGPL-3.0 第 13 条：与本实例交互的用户有权获取其对应版本的源代码。",
+    "authorHeading": "作者",
+    "authorGithub": "GitHub 主页",
+    "sourceHeading": "源代码",
+    "sourceDescription": "Ech0 的完整源代码在 GitHub 上公开可用。",
+    "viewSource": "在 GitHub 上查看源代码",
+    "viewRelease": "v{version} 发布说明",
+    "poweredBy": "用心打造 · Powered by Ech0"
+  },
   "echoPage": {
     "loadingDetail": "正在加载 Echo 详情..."
   },

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import 'virtual:uno.css'
 import '@/themes/index.scss'
 import 'floating-vue/dist/style.css'

--- a/web/src/plugins/welcome-plugin.ts
+++ b/web/src/plugins/welcome-plugin.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { Plugin } from 'vite'
 import { printWelcome } from '../scripts/welcome.js'
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -152,6 +152,15 @@ const router = createRouter({
       },
     },
     {
+      path: '/about',
+      name: 'about',
+      component: () => import('../views/about/AboutView.vue'),
+      meta: {
+        title: 'About',
+        description: 'Copyright, license and author information for this Ech0 instance.',
+      },
+    },
+    {
       path: '/:pathMatch(.*)*',
       name: 'not-found',
       component: () => import('../views/404/NotFoundView.vue'),

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { createRouter, createWebHistory } from 'vue-router'
 import { useInitStore } from '@/stores/init'
 import { useUserStore } from '@/stores/user'

--- a/web/src/scripts/welcome.ts
+++ b/web/src/scripts/welcome.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import chalk from 'chalk'
 
 // ASCII Art Banner

--- a/web/src/service/api/agent.ts
+++ b/web/src/service/api/agent.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request } from '../request'
 
 // 获取近况总结

--- a/web/src/service/api/auth.ts
+++ b/web/src/service/api/auth.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request } from '../request'
 
 // 登录

--- a/web/src/service/api/comment.ts
+++ b/web/src/service/api/comment.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request } from '../request'
 
 export function fetchGetCommentFormMeta() {

--- a/web/src/service/api/connect.ts
+++ b/web/src/service/api/connect.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request, requestWithDirectUrl } from '../request'
 
 // 获取Connect列表

--- a/web/src/service/api/dashboard.ts
+++ b/web/src/service/api/dashboard.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request } from '../request'
 
 export function fetchGetVisitorStats() {

--- a/web/src/service/api/echo.ts
+++ b/web/src/service/api/echo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request, requestWithDirectUrlAndData } from '../request'
 
 // 统一查询 Echos（支持分页、搜索、标签过滤、排序）

--- a/web/src/service/api/file.ts
+++ b/web/src/service/api/file.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { downloadFile, request } from '../request'
 import { FILE_CATEGORY, FILE_STORAGE_TYPE } from '@/constants/file'
 

--- a/web/src/service/api/index.ts
+++ b/web/src/service/api/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export * from './auth.ts'
 export * from './user.ts'
 export * from './echo.ts'

--- a/web/src/service/api/init.ts
+++ b/web/src/service/api/init.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request } from '../request'
 
 export function fetchGetInitStatus() {

--- a/web/src/service/api/other.ts
+++ b/web/src/service/api/other.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request, downloadFile } from '../request'
 
 // Hello Ech0

--- a/web/src/service/api/setting.ts
+++ b/web/src/service/api/setting.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request } from '../request'
 
 // 获取系统设置

--- a/web/src/service/api/system-log.ts
+++ b/web/src/service/api/system-log.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request } from '../request'
 
 export function fetchSystemLogs(params: App.Api.SystemLog.QueryParams) {

--- a/web/src/service/api/user.ts
+++ b/web/src/service/api/user.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { request } from '../request'
 
 // 获取当前登录用户信息

--- a/web/src/service/request/index.ts
+++ b/web/src/service/request/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { ofetch } from 'ofetch'
 import { getInitReadyStatus } from './shared'
 import { useAuthStore } from '@/stores/auth'

--- a/web/src/service/request/shared.ts
+++ b/web/src/service/request/shared.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { localStg } from '@/utils/storage'
 
 export const getApiUrl = () => {

--- a/web/src/service/request/websocket.ts
+++ b/web/src/service/request/websocket.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { useWebSocket } from '@vueuse/core'
 import { reactive, watch } from 'vue'
 import { i18n } from '@/locales'

--- a/web/src/shims-vue.d.ts
+++ b/web/src/shims-vue.d.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 declare module '*.vue' {
   import { DefineComponent } from 'vue'
   const component: DefineComponent<object, object, unknown>

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { computed, ref } from 'vue'
 import { defineStore } from 'pinia'
 import { ofetch } from 'ofetch'

--- a/web/src/stores/connect.ts
+++ b/web/src/stores/connect.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import { fetchGetConnectList, fetchGetAllConnectInfo } from '@/service/api'

--- a/web/src/stores/echo.ts
+++ b/web/src/stores/echo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineStore } from 'pinia'
 import { ref, computed, watch } from 'vue'
 import { fetchQueryEchos, fetchGetTags, fetchGetEchoById } from '@/service/api'

--- a/web/src/stores/editor/index.ts
+++ b/web/src/stores/editor/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { theToast } from '@/utils/toast'

--- a/web/src/stores/editor/types.ts
+++ b/web/src/stores/editor/types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export type LocationToAdd = {
   latitude: number | null
   longitude: number | null

--- a/web/src/stores/editor/useDraftModule.ts
+++ b/web/src/stores/editor/useDraftModule.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { ref, watch, type Ref } from 'vue'
 import { ImageLayout } from '@/enums/enums'
 import { localStg } from '@/utils/storage'

--- a/web/src/stores/editor/useExtensionModule.ts
+++ b/web/src/stores/editor/useExtensionModule.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { computed, ref, type Ref } from 'vue'
 import { ExtensionType } from '@/enums/enums'
 import { theToast } from '@/utils/toast'

--- a/web/src/stores/editor/useFilesModule.ts
+++ b/web/src/stores/editor/useFilesModule.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { computed, ref } from 'vue'
 import { FILE_CATEGORY, FILE_STORAGE_TYPE } from '@/constants/file'
 import { createExternalFile, globalFileRegistry, useFileAttachments } from '@/lib/file'

--- a/web/src/stores/hub.ts
+++ b/web/src/stores/hub.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { useFetch } from '@vueuse/core'

--- a/web/src/stores/index.ts
+++ b/web/src/stores/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 export * from './store-init'
 export * from './theme'
 export * from './auth'

--- a/web/src/stores/init.ts
+++ b/web/src/stores/init.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { fetchGetInitStatus, fetchInitOwner } from '@/service/api'

--- a/web/src/stores/migration.ts
+++ b/web/src/stores/migration.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import {

--- a/web/src/stores/setting.ts
+++ b/web/src/stores/setting.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import {

--- a/web/src/stores/store-init.ts
+++ b/web/src/stores/store-init.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { useThemeStore } from './theme'
 import { useUserStore } from './user'
 import { useSettingStore } from './setting'

--- a/web/src/stores/theme.ts
+++ b/web/src/stores/theme.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { localStg } from '@/utils/storage'

--- a/web/src/stores/user.ts
+++ b/web/src/stores/user.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import { fetchLogin, fetchSignup, fetchGetCurrentUser, fetchExchangeCode } from '@/service/api'

--- a/web/src/typings/app.d.ts
+++ b/web/src/typings/app.d.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 declare namespace App {
   /**
    * Namespace Api
@@ -312,8 +315,13 @@ declare namespace App {
 
       type HelloEch0 = {
         hello: string
+        copyright: string
         version: string
-        github: string
+        commit: string
+        build_time: string
+        license: string
+        author: string
+        repo_url: string
       }
 
       type PresignResult = {

--- a/web/src/typings/vue-virtual-scroller.d.ts
+++ b/web/src/typings/vue-virtual-scroller.d.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 declare module 'vue-virtual-scroller' {
   import type { DefineComponent } from 'vue'
 

--- a/web/src/utils/cron.ts
+++ b/web/src/utils/cron.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import type { ComposerTranslation } from 'vue-i18n'
 
 export type CronFrequency = 'daily' | 'weekly' | 'monthly' | 'hourly' | 'custom'

--- a/web/src/utils/echo.ts
+++ b/web/src/utils/echo.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { FILE_STORAGE_TYPE } from '@/constants/file'
 import { filterFiles, type FileSelectorOptions } from '@/lib/file'
 

--- a/web/src/utils/file.ts
+++ b/web/src/utils/file.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 const SIZE_UNITS = ['B', 'KB', 'MB', 'GB'] as const
 
 // Render a byte count as a short human label (e.g. 234 KB, 1.2 MB).

--- a/web/src/utils/image.ts
+++ b/web/src/utils/image.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // 获取图片尺寸
 export function getImageSize(imgUrl: string): Promise<{ width: number; height: number }> {
   return new Promise((resolve, reject) => {

--- a/web/src/utils/loadExternalAsset.ts
+++ b/web/src/utils/loadExternalAsset.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 const scriptLoadPromises = new Map<string, Promise<void>>()
 const styleLoadPromises = new Map<string, Promise<void>>()
 

--- a/web/src/utils/other.ts
+++ b/web/src/utils/other.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { MusicProvider } from '@/enums/enums'
 import { i18n, DEFAULT_LOCALE } from '@/locales'
 import { timeValueToMs } from './timeValue'

--- a/web/src/utils/storage.ts
+++ b/web/src/utils/storage.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // 处理LocalStorage的工具函数
 
 export const localStg = {

--- a/web/src/utils/timeValue.ts
+++ b/web/src/utils/timeValue.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /**
  * 将「存储层时间」统一为毫秒时间戳。
  *

--- a/web/src/utils/toast.ts
+++ b/web/src/utils/toast.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 // 处理全局通知工具函数 (基于 vue-sonner)
 import { toast } from 'vue-sonner'
 

--- a/web/src/views/404/NotFoundView.vue
+++ b/web/src/views/404/NotFoundView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import NotFoundPage from './modules/NotFoundPage.vue'
 </script>

--- a/web/src/views/404/modules/NotFoundPage.vue
+++ b/web/src/views/404/modules/NotFoundPage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="flex justify-center items-center h-screen relative">
     <div>

--- a/web/src/views/about/AboutView.vue
+++ b/web/src/views/about/AboutView.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import AboutPage from './modules/AboutPage.vue'
+</script>
+
+<template>
+  <main class="w-full">
+    <AboutPage />
+  </main>
+</template>

--- a/web/src/views/about/AboutView.vue
+++ b/web/src/views/about/AboutView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import AboutPage from './modules/AboutPage.vue'
 </script>

--- a/web/src/views/about/modules/AboutPage.vue
+++ b/web/src/views/about/modules/AboutPage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="about-page">
     <div class="about-shell">
@@ -12,7 +14,8 @@
         <div class="about-title">
           <h1 class="about-title__name">Ech0</h1>
           <span class="about-title__version">
-            v{{ settingStore.hello?.version || '--' }}
+            v{{ version }}
+            <span v-if="hasCommit" class="about-title__commit"> · {{ commit }}</span>
           </span>
         </div>
         <p class="about-title__tagline">{{ t('about.tagline') }}</p>
@@ -20,18 +23,16 @@
 
       <section class="about-card">
         <h2 class="about-card__heading">{{ t('about.copyrightHeading') }}</h2>
-        <p class="about-card__text">
-          {{ t('about.copyrightLine', { year: copyrightYears, holder: AUTHOR_NAME }) }}
-        </p>
+        <p class="about-card__text">{{ copyright }}</p>
         <p class="about-card__text about-card__text--muted">
           {{ t('about.licenseLine') }}
           <a
-            :href="`${REPO_URL}/blob/main/LICENSE`"
+            :href="`${repoURL}/blob/main/LICENSE`"
             target="_blank"
             rel="noopener noreferrer"
             class="about-link"
           >
-            AGPL-3.0-or-later
+            {{ license }}
           </a>
         </p>
         <p class="about-card__text about-card__text--muted">
@@ -41,7 +42,7 @@
 
       <section class="about-card">
         <h2 class="about-card__heading">{{ t('about.authorHeading') }}</h2>
-        <p class="about-card__text">{{ AUTHOR_NAME }}</p>
+        <p class="about-card__text">{{ author }}</p>
         <div class="about-links">
           <a
             :href="AUTHOR_GITHUB"
@@ -62,24 +63,27 @@
         </p>
         <div class="about-links">
           <a
-            :href="REPO_URL"
+            :href="sourceURL"
             target="_blank"
             rel="noopener noreferrer"
             class="about-link about-link--row"
           >
             <Github class="about-link__icon" />
-            <span>{{ t('about.viewSource') }}</span>
+            <span>{{ sourceLinkLabel }}</span>
           </a>
           <a
-            :href="`${REPO_URL}/releases/tag/v${settingStore.hello?.version}`"
+            v-if="version && version !== '--'"
+            :href="`${repoURL}/releases/tag/v${version}`"
             target="_blank"
             rel="noopener noreferrer"
             class="about-link about-link--row"
-            v-if="settingStore.hello?.version"
           >
             <Info class="about-link__icon" />
-            <span>{{ t('about.viewRelease', { version: settingStore.hello.version }) }}</span>
+            <span>{{ t('about.viewRelease', { version }) }}</span>
           </a>
+          <p v-if="buildTime" class="about-card__text about-card__text--muted about-build-time">
+            {{ t('about.buildTime', { time: buildTime }) }}
+          </p>
         </div>
       </section>
 
@@ -102,15 +106,35 @@ import Info from '@/components/icons/info.vue'
 const { t } = useI18n()
 const settingStore = useSettingStore()
 
-const AUTHOR_NAME = 'lin-snow'
+// Author profile URL is intentionally hardcoded — it points to the person's
+// GitHub user page, not to the repository, so it is not part of /hello.
 const AUTHOR_GITHUB = 'https://github.com/lin-snow'
-const REPO_URL = 'https://github.com/lin-snow/Ech0'
-const PROJECT_START_YEAR = 2024
 
-const copyrightYears = computed(() => {
-  const current = new Date().getFullYear()
-  return current > PROJECT_START_YEAR ? `${PROJECT_START_YEAR}-${current}` : `${PROJECT_START_YEAR}`
-})
+const FALLBACK_REPO = 'https://github.com/lin-snow/Ech0'
+const FALLBACK_AUTHOR = 'lin-snow'
+const FALLBACK_LICENSE = 'AGPL-3.0-or-later'
+
+const version = computed(() => settingStore.hello?.version || '--')
+const commit = computed(() => settingStore.hello?.commit || '')
+const hasCommit = computed(() => commit.value !== '' && commit.value !== 'unknown')
+const buildTime = computed(() => settingStore.hello?.build_time || '')
+const author = computed(() => settingStore.hello?.author || FALLBACK_AUTHOR)
+const license = computed(() => settingStore.hello?.license || FALLBACK_LICENSE)
+const repoURL = computed(() => settingStore.hello?.repo_url || FALLBACK_REPO)
+const copyright = computed(
+  () => settingStore.hello?.copyright || `Copyright (C) ${new Date().getFullYear()} ${author.value}`,
+)
+
+// AGPL-3.0 §13 anchor: when we know the exact commit, link the user to /tree/<commit>
+// so the source they receive matches the running binary. Falls back to repo root.
+const sourceURL = computed(() =>
+  hasCommit.value ? `${repoURL.value}/tree/${commit.value}` : repoURL.value,
+)
+const sourceLinkLabel = computed(() =>
+  hasCommit.value
+    ? t('about.viewSourceAtCommit', { commit: commit.value })
+    : t('about.viewSource'),
+)
 </script>
 
 <style scoped>
@@ -165,6 +189,12 @@ const copyrightYears = computed(() => {
   font-size: 0.875rem;
   font-weight: 600;
   color: var(--color-text-secondary);
+}
+
+.about-title__commit {
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, monospace);
+  font-weight: 500;
+  color: var(--color-text-muted);
 }
 
 .about-title__tagline {
@@ -239,6 +269,13 @@ const copyrightYears = computed(() => {
   font-size: 1.125rem;
   color: var(--color-text-secondary);
   transition: color 0.15s ease;
+}
+
+.about-build-time {
+  margin-top: 0.25rem;
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
 }
 
 .about-footer {

--- a/web/src/views/about/modules/AboutPage.vue
+++ b/web/src/views/about/modules/AboutPage.vue
@@ -1,0 +1,250 @@
+<template>
+  <div class="about-page">
+    <div class="about-shell">
+      <header class="about-header">
+        <BaseButton
+          @click="$router.push({ name: 'home' })"
+          :tooltip="t('commonNav.backHome')"
+          class="about-back"
+        >
+          <Arrow class="text-2xl rotate-180" />
+        </BaseButton>
+        <div class="about-title">
+          <h1 class="about-title__name">Ech0</h1>
+          <span class="about-title__version">
+            v{{ settingStore.hello?.version || '--' }}
+          </span>
+        </div>
+        <p class="about-title__tagline">{{ t('about.tagline') }}</p>
+      </header>
+
+      <section class="about-card">
+        <h2 class="about-card__heading">{{ t('about.copyrightHeading') }}</h2>
+        <p class="about-card__text">
+          {{ t('about.copyrightLine', { year: copyrightYears, holder: AUTHOR_NAME }) }}
+        </p>
+        <p class="about-card__text about-card__text--muted">
+          {{ t('about.licenseLine') }}
+          <a
+            :href="`${REPO_URL}/blob/main/LICENSE`"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="about-link"
+          >
+            AGPL-3.0-or-later
+          </a>
+        </p>
+        <p class="about-card__text about-card__text--muted">
+          {{ t('about.agplNotice') }}
+        </p>
+      </section>
+
+      <section class="about-card">
+        <h2 class="about-card__heading">{{ t('about.authorHeading') }}</h2>
+        <p class="about-card__text">{{ AUTHOR_NAME }}</p>
+        <div class="about-links">
+          <a
+            :href="AUTHOR_GITHUB"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="about-link about-link--row"
+          >
+            <Github class="about-link__icon" />
+            <span>{{ t('about.authorGithub') }}</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="about-card">
+        <h2 class="about-card__heading">{{ t('about.sourceHeading') }}</h2>
+        <p class="about-card__text about-card__text--muted">
+          {{ t('about.sourceDescription') }}
+        </p>
+        <div class="about-links">
+          <a
+            :href="REPO_URL"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="about-link about-link--row"
+          >
+            <Github class="about-link__icon" />
+            <span>{{ t('about.viewSource') }}</span>
+          </a>
+          <a
+            :href="`${REPO_URL}/releases/tag/v${settingStore.hello?.version}`"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="about-link about-link--row"
+            v-if="settingStore.hello?.version"
+          >
+            <Info class="about-link__icon" />
+            <span>{{ t('about.viewRelease', { version: settingStore.hello.version }) }}</span>
+          </a>
+        </div>
+      </section>
+
+      <footer class="about-footer">
+        <span>{{ t('about.poweredBy') }}</span>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useSettingStore } from '@/stores'
+import BaseButton from '@/components/common/BaseButton.vue'
+import Arrow from '@/components/icons/arrow.vue'
+import Github from '@/components/icons/github.vue'
+import Info from '@/components/icons/info.vue'
+
+const { t } = useI18n()
+const settingStore = useSettingStore()
+
+const AUTHOR_NAME = 'lin-snow'
+const AUTHOR_GITHUB = 'https://github.com/lin-snow'
+const REPO_URL = 'https://github.com/lin-snow/Ech0'
+const PROJECT_START_YEAR = 2024
+
+const copyrightYears = computed(() => {
+  const current = new Date().getFullYear()
+  return current > PROJECT_START_YEAR ? `${PROJECT_START_YEAR}-${current}` : `${PROJECT_START_YEAR}`
+})
+</script>
+
+<style scoped>
+.about-page {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  min-height: 100vh;
+  padding: 1.5rem 1rem 4rem;
+}
+
+.about-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 42rem;
+}
+
+.about-header {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2rem 1rem 1rem;
+  text-align: center;
+}
+
+.about-back {
+  position: absolute;
+  top: 0.5rem;
+  left: 0;
+  border-radius: var(--radius-xs);
+}
+
+.about-title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.about-title__name {
+  margin: 0;
+  font-family: var(--font-family-display);
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.about-title__version {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.about-title__tagline {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: var(--color-text-secondary);
+}
+
+.about-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.125rem;
+  background: var(--color-bg-surface);
+  border-radius: var(--radius-xs);
+  box-shadow: var(--shadow-soft);
+}
+
+.about-card__heading {
+  margin: 0 0 0.25rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.about-card__text {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  color: var(--color-text-primary);
+}
+
+.about-card__text--muted {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+
+.about-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  margin-top: 0.25rem;
+}
+
+.about-link {
+  color: var(--color-text-primary);
+  text-decoration: underline;
+  text-decoration-color: var(--color-text-muted);
+  text-underline-offset: 0.2em;
+  transition: text-decoration-color 0.15s ease;
+}
+
+.about-link:hover {
+  text-decoration-color: var(--color-text-primary);
+}
+
+.about-link--row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  font-size: 0.9375rem;
+}
+
+.about-link--row:hover .about-link__icon {
+  color: var(--color-text-primary);
+}
+
+.about-link__icon {
+  font-size: 1.125rem;
+  color: var(--color-text-secondary);
+  transition: color 0.15s ease;
+}
+
+.about-footer {
+  margin-top: 0.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+</style>

--- a/web/src/views/auth/AuthView.vue
+++ b/web/src/views/auth/AuthView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import AuthPage from './modules/AuthPage.vue'
 </script>

--- a/web/src/views/auth/modules/AuthPage.vue
+++ b/web/src/views/auth/modules/AuthPage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="flex justify-center items-center h-screen">
     <div class="h-1/2 w-[min(86vw,12rem)] sm:w-[min(82vw,18rem)] md:w-[15rem]">

--- a/web/src/views/echo/EchoView.vue
+++ b/web/src/views/echo/EchoView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import EchoPage from './modules/EchoPage.vue'
 </script>

--- a/web/src/views/echo/modules/EchoPage.vue
+++ b/web/src/views/echo/modules/EchoPage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="px-3 pb-4 py-2 mt-4 sm:mt-6 mb-10 mx-auto flex justify-center items-center">
     <div class="w-full sm:max-w-lg mx-auto">

--- a/web/src/views/home/HomeView.vue
+++ b/web/src/views/home/HomeView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import HomePage from './modules/HomePage.vue'
 </script>

--- a/web/src/views/home/modules/HomeBanner.vue
+++ b/web/src/views/home/modules/HomeBanner.vue
@@ -4,13 +4,20 @@
       <p class="home-banner__line">{{ t('homeBio.tagline') }}</p>
     </div>
     <div class="home-banner__meta">
-      <span class="home-banner__powered">Powered by Ech0</span>
+      <RouterLink
+        :to="{ name: 'about' }"
+        class="home-banner__powered"
+        :aria-label="t('about.linkAriaLabel')"
+      >
+        Powered by Ech0
+      </RouterLink>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { RouterLink } from 'vue-router'
 const { t } = useI18n()
 </script>
 
@@ -66,5 +73,12 @@ const { t } = useI18n()
   font-weight: 600;
   line-height: 1.35;
   color: var(--color-text-secondary);
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.home-banner__powered:hover {
+  color: var(--color-text-primary);
 }
 </style>

--- a/web/src/views/home/modules/HomeBanner.vue
+++ b/web/src/views/home/modules/HomeBanner.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <section class="home-banner" aria-label="Intro">
     <div class="home-banner__top">

--- a/web/src/views/home/modules/HomeHeader.vue
+++ b/web/src/views/home/modules/HomeHeader.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="home-header">
     <div class="home-header__brand">

--- a/web/src/views/home/modules/HomePage.vue
+++ b/web/src/views/home/modules/HomePage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="home-page">
     <div class="home-shell">

--- a/web/src/views/home/modules/HomeSidebarNav.vue
+++ b/web/src/views/home/modules/HomeSidebarNav.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="home-sidebar-nav">
     <div class="home-sidebar-nav__mobile-row">

--- a/web/src/views/home/modules/TheCommandPalette.vue
+++ b/web/src/views/home/modules/TheCommandPalette.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <Teleport to="body">
     <Transition name="palette">

--- a/web/src/views/home/modules/TheEchos.vue
+++ b/web/src/views/home/modules/TheEchos.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="mx-auto mt-1 sm:mt-0 mb-4 sm:mb-5 md:mb-6"

--- a/web/src/views/home/modules/TheEditor.vue
+++ b/web/src/views/home/modules/TheEditor.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div v-if="ShowEditor" class="editor-shell">
     <div class="editor-shell__inner">

--- a/web/src/views/home/modules/TheEditor/TheEditorButtons.vue
+++ b/web/src/views/home/modules/TheEditor/TheEditorButtons.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="editor-actions">
     <div class="editor-actions__left">

--- a/web/src/views/home/modules/TheEditor/TheEditorImage.vue
+++ b/web/src/views/home/modules/TheEditor/TheEditorImage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <!-- 图片预览 -->
   <div

--- a/web/src/views/home/modules/TheEditor/TheExtensionEditor.vue
+++ b/web/src/views/home/modules/TheEditor/TheExtensionEditor.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div>
     <!-- 音乐分享 -->

--- a/web/src/views/home/modules/TheEditor/TheImageEditor.vue
+++ b/web/src/views/home/modules/TheEditor/TheImageEditor.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="editor-image-panel">
     <h2 class="text-[var(--color-text-secondary)] font-bold my-2">

--- a/web/src/views/home/modules/TheEditor/TheModePanel.vue
+++ b/web/src/views/home/modules/TheEditor/TheModePanel.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="editor-mode-panel p-3 my-3 border border-dashed border-[var(--dash-line-color)] rounded-xs"

--- a/web/src/views/home/modules/TheEditor/TheTagsManager.vue
+++ b/web/src/views/home/modules/TheEditor/TheTagsManager.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="py-4">
     <h2 class="text-[var(--color-text-secondary)] font-bold mb-2">

--- a/web/src/views/home/modules/TheFilter.vue
+++ b/web/src/views/home/modules/TheFilter.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full sm:px-2 mb-1 sm:mb-0">
     <div class="w-full flex flex-col gap-2">

--- a/web/src/views/hub/HubView.vue
+++ b/web/src/views/hub/HubView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import HubPage from './modules/HubPage.vue'
 </script>

--- a/web/src/views/hub/modules/HubPage.vue
+++ b/web/src/views/hub/modules/HubPage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div
     class="w-full px-2 pb-4 py-2 mt-4 sm:mt-0 mb-10 sm:mb-0 mx-auto flex justify-center items-start"

--- a/web/src/views/init/InitView.vue
+++ b/web/src/views/init/InitView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import InitPage from './modules/InitPage.vue'
 </script>

--- a/web/src/views/init/modules/InitPage.vue
+++ b/web/src/views/init/modules/InitPage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <main class="min-h-screen w-full px-4 flex items-center justify-center">
     <div class="w-full max-w-[18rem]">

--- a/web/src/views/init/modules/TheInitForm.vue
+++ b/web/src/views/init/modules/TheInitForm.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <section
     class="w-full rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg-muted)]/40 p-3 sm:p-3.5"

--- a/web/src/views/init/modules/TheInitIntro.vue
+++ b/web/src/views/init/modules/TheInitIntro.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <section class="mb-3 text-center">
     <p class="text-[10px] tracking-[0.16em] uppercase text-[var(--color-text-secondary)] mb-2">

--- a/web/src/views/panel/PanelView.vue
+++ b/web/src/views/panel/PanelView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import PanelPage from './modules/PanelPage.vue'
 import { onMounted } from 'vue'

--- a/web/src/views/panel/modules/PanelPage.vue
+++ b/web/src/views/panel/modules/PanelPage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="panel-page-wrap mt-4">
     <div class="panel-shell border p-4 mx-auto flex flex-col max-w-screen-lg w-full mb-12">

--- a/web/src/views/panel/modules/TheAdvance.vue
+++ b/web/src/views/panel/modules/TheAdvance.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full px-2">
     <!-- Webhook 设置 -->

--- a/web/src/views/panel/modules/TheCommentManager.vue
+++ b/web/src/views/panel/modules/TheCommentManager.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full px-2 comment-manager-page">
     <PanelCard class="mb-4">

--- a/web/src/views/panel/modules/TheDashboard.vue
+++ b/web/src/views/panel/modules/TheDashboard.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import { usePreferredReducedMotion, useTransition } from '@vueuse/core'
 import { computed, onMounted, ref } from 'vue'

--- a/web/src/views/panel/modules/TheDataManagement.vue
+++ b/web/src/views/panel/modules/TheDataManagement.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full px-2 space-y-3">
     <!-- 数据迁移 -->

--- a/web/src/views/panel/modules/TheExtension.vue
+++ b/web/src/views/panel/modules/TheExtension.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full px-2">
     <!-- 连接设置 -->

--- a/web/src/views/panel/modules/TheSSO.vue
+++ b/web/src/views/panel/modules/TheSSO.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full px-2">
     <!-- OAuth2 设置 -->

--- a/web/src/views/panel/modules/TheSetting.vue
+++ b/web/src/views/panel/modules/TheSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full px-2">
     <!-- 系统设置 -->

--- a/web/src/views/panel/modules/TheSetting/TheAccessTokenSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheAccessTokenSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <!-- Webhook 设置 -->

--- a/web/src/views/panel/modules/TheSetting/TheAgentSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheAgentSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <!-- Agent 设置 -->

--- a/web/src/views/panel/modules/TheSetting/TheBackupScheduleSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheBackupScheduleSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <div class="w-full space-y-3">

--- a/web/src/views/panel/modules/TheSetting/TheBackupSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheBackupSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <div class="backup-wrap">

--- a/web/src/views/panel/modules/TheSetting/TheConnectSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheConnectSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <div class="w-full">

--- a/web/src/views/panel/modules/TheSetting/TheMigrationSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheMigrationSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <div class="migration-wrap">

--- a/web/src/views/panel/modules/TheSetting/TheOAuth2Setting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheOAuth2Setting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div>
     <PanelCard class="mb-3">

--- a/web/src/views/panel/modules/TheSetting/ThePasskeySetting.vue
+++ b/web/src/views/panel/modules/TheSetting/ThePasskeySetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <div class="w-full">

--- a/web/src/views/panel/modules/TheSetting/TheStorageFileList.vue
+++ b/web/src/views/panel/modules/TheSetting/TheStorageFileList.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import PanelCard from '@/layout/PanelCard.vue'
 import { FILE_STORAGE_TYPE } from '@/constants/file'

--- a/web/src/views/panel/modules/TheSetting/TheStorageSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheStorageSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <!-- 存储设置 -->

--- a/web/src/views/panel/modules/TheSetting/TheSystemSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheSystemSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <!-- 系统设置 -->

--- a/web/src/views/panel/modules/TheSetting/TheUserManager.vue
+++ b/web/src/views/panel/modules/TheSetting/TheUserManager.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <div class="flex flex-row items-center justify-between mb-3">

--- a/web/src/views/panel/modules/TheSetting/TheUserSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheUserSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <!-- 用户设置 -->

--- a/web/src/views/panel/modules/TheSetting/TheWebhookSetting.vue
+++ b/web/src/views/panel/modules/TheSetting/TheWebhookSetting.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <PanelCard>
     <div class="w-full">

--- a/web/src/views/panel/modules/TheSetting/components/CronScheduleEditor.vue
+++ b/web/src/views/panel/modules/TheSetting/components/CronScheduleEditor.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="cron-editor">
     <div class="cron-editor__grid">

--- a/web/src/views/panel/modules/TheStorage.vue
+++ b/web/src/views/panel/modules/TheStorage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full px-2">
     <!-- 存储设置 -->

--- a/web/src/views/panel/modules/TheSystemLog.vue
+++ b/web/src/views/panel/modules/TheSystemLog.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full px-2">
     <div class="mb-3 log-toolbar">

--- a/web/src/views/panel/modules/TheUser.vue
+++ b/web/src/views/panel/modules/TheUser.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="w-full px-2">
     <!-- 用户设置 -->

--- a/web/src/views/widget/WidgetView.vue
+++ b/web/src/views/widget/WidgetView.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <script setup lang="ts">
 import WidgetPage from './modules/WidgetPage.vue'
 </script>

--- a/web/src/views/widget/modules/WidgetPage.vue
+++ b/web/src/views/widget/modules/WidgetPage.vue
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="px-4 pb-4 py-2 mx-auto flex flex-col w-sm md:w-sm mt-4 mb-12">
     <h1

--- a/web/tests/editor/markdown.performance.test.ts
+++ b/web/tests/editor/markdown.performance.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { describe, expect, it } from 'vitest'
 import { performance } from 'node:perf_hooks'
 import { renderMarkdown } from '../../src/editor/core/markdown'

--- a/web/tests/editor/markdown.renderer.test.ts
+++ b/web/tests/editor/markdown.renderer.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { describe, expect, it } from 'vitest'
 import { renderMarkdown } from '../../src/editor/core/markdown'
 

--- a/web/tests/editor/markdown.task-list.test.ts
+++ b/web/tests/editor/markdown.task-list.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { describe, expect, it } from 'vitest'
 import { renderMarkdown } from '../../src/editor/core/markdown'
 

--- a/web/tests/gallery/TheImageGallery.test.ts
+++ b/web/tests/gallery/TheImageGallery.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineComponent } from 'vue'
 import { mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'

--- a/web/tests/gallery/usePhotoSwipeGallery.test.ts
+++ b/web/tests/gallery/usePhotoSwipeGallery.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineComponent, ref } from 'vue'
 import { mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'

--- a/web/tests/lib/file/compress.test.ts
+++ b/web/tests/lib/file/compress.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { compressImage, inferFileExtFromType } from '../../../src/lib/file/compress'

--- a/web/tests/lib/file/upload.test.ts
+++ b/web/tests/lib/file/upload.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { httpUpload, UploadError } from '../../../src/lib/file/upload'

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { afterEach, vi } from 'vitest'
 
 const createStorageMock = () => {

--- a/web/tests/stores/setting.init.test.ts
+++ b/web/tests/stores/setting.init.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { useSettingStore } from '@/stores/setting'

--- a/web/tests/utils/loadExternalAsset.test.ts
+++ b/web/tests/utils/loadExternalAsset.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { describe, expect, it, vi } from 'vitest'
 
 import { loadExternalScript, loadExternalStyle } from '../../src/utils/loadExternalAsset'

--- a/web/uno.config.ts
+++ b/web/uno.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 import { defineConfig } from 'unocss'
 import presetWind4 from '@unocss/preset-wind4'
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
 /// <reference types="vitest/config" />
 import { fileURLToPath, URL } from 'node:url'
 


### PR DESCRIPTION
## Summary

This PR closes the AGPL-3.0 §13 hole — there was no in-app way for a network user to find the corresponding source code of the running instance — and tidies up where build/copyright metadata lives in the codebase.

Three logically-distinct commits, intentionally ordered for review:

1. **`feat(backend): extract internal/version package + inject build metadata`** — Moves `Version` out of `internal/model/common` (which is a domain-model package) into a new dedicated `internal/version` package, alongside `License`, `Author`, `RepoURL`, `StartYear` consts and ldflags-injected `Commit` / `BuildTime` vars. Plumbs the injection through `Makefile` / `.air.toml` / `docker/build.Dockerfile` / `.github/workflows/release.yml`. The `/hello` handler now flattens `versionPkg.Info` into its JSON response so the frontend has a single source of truth. 9 callers of the old `commonModel.Version` migrated.

2. **`feat(web): wire commit hash + license metadata into About page`** — The About page (added in 187e01f9) now reads version / commit / build_time / license / author / repo_url straight from `/hello` instead of hardcoding them. The "View source" link now points to `https://github.com/lin-snow/Ech0/tree/<commit>` — that's the AGPL §13 anchor, the precise source corresponding to the running binary. Title bar shows `v4.6.4 · abc1234` when commit is known. Adds `license` / `author` / `homepage` fields to `web/package.json`.

3. **`chore: prepend SPDX/Copyright headers to source files`** — Mechanical batch addition of a 2-line `SPDX-License-Identifier: AGPL-3.0-or-later` + `Copyright (C) 2025-2026 lin-snow` header to every `.go` / `.ts` / `.vue` source file (502 files). Driven by a new idempotent script `scripts/add-spdx-headers.mjs` (write / `--dry-run` / `--check` modes). Skips generated files (`internal/swagger`, `wire_gen.go`), upstream-attributed icons, and vendored dirs. Correctly handles `//go:build` constraints.

## Why now

Selecting AGPL-3.0 means accepting §13: users interacting with a network instance must be able to obtain the corresponding source. Previously this repo had only a generic GitHub link in a footer — fine for the canonical instance, but anyone forking Ech0 with their own changes (the case AGPL is designed to defend against) had no UI affordance to ship that obligation.

After this PR, the About page links to the exact tree at the running commit. The cost is small (one ldflags var per build target, one Vue page); the alignment with the chosen license is meaningful.

## Notes for reviewers

- The 502-file SPDX commit is intentionally last so commits 1 & 2 read as focused, reviewable diffs. Commit 3 is mechanical and safe to skim.
- `/hello` response shape changed: dropped legacy `github` field, added `commit`, `build_time`, `license`, `author`, `repo_url`, `copyright`. No production frontend code referenced `github`; verified via grep.
- License identifier is `AGPL-3.0-or-later` (allows downstream to opt into future AGPL versions). Not `-only`.
- `bin/` added to `.gitignore` for the new `make build` target.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] `golangci-lint run` 0 issues
- [x] `make wire-check` no drift
- [x] `make swagger` no drift
- [x] `pnpm i18n:check` 4 sub-checks pass
- [x] `pnpm lint`, `pnpm lint:style`, `pnpm type-check`, `pnpm build` all clean
- [x] `node scripts/add-spdx-headers.mjs --check` reports 522 covered, 0 missing
- [x] ldflags injection smoke test confirms `Commit=<hash>` and `BuildTime=<rfc3339>` flow through `versionPkg.Get()` end-to-end
- [x] Vite dev server serves `/about` (HTTP 200)
- [ ] Manual: load `/about` against a make-built backend, confirm "View source @ <commit>" link points to a real tree URL on GitHub
- [ ] Manual: confirm `make build` produces `./bin/ech0` with correct version/commit/build_time when running `ech0` against `/hello`

🤖 Generated with [Claude Code](https://claude.com/claude-code)