### PR TITLE
ci(release): guard against tag/version drift before building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,40 @@ env:
   MUSL_TOOLCHAIN_SHA256: ""
 
 jobs:
+  # Refuse to build a release when the tag (vX.Y.Z) and the Version constant
+  # in internal/version/version.go disagree. Otherwise the published artifacts
+  # would lie about their own version in /hello, /healthz, the About page, etc.
+  verify-version:
+    name: Verify tag matches internal/version.Version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compare tag and source version
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          TAG_VERSION="${TAG#v}"
+          SRC_VERSION="$(grep -E '^[[:space:]]*Version[[:space:]]*=[[:space:]]*"' internal/version/version.go \
+                          | head -n1 \
+                          | sed -E 's/.*"([^"]+)".*/\1/')"
+
+          if [ -z "$SRC_VERSION" ]; then
+            echo "::error::Could not extract Version from internal/version/version.go"
+            exit 1
+          fi
+
+          echo "tag        = ${TAG}"
+          echo "tag_version = ${TAG_VERSION}"
+          echo "src_version = ${SRC_VERSION}"
+
+          if [ "$TAG_VERSION" != "$SRC_VERSION" ]; then
+            echo "::error title=Version mismatch::Git tag ${TAG} → ${TAG_VERSION}, but internal/version/version.go declares ${SRC_VERSION}. Bump the const before tagging (see docs/dev/release-process.md)."
+            exit 1
+          fi
+
   build:
     name: Build Frontend & Backend
+    needs: [verify-version]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Adds a `verify-version` job at the front of the release workflow that refuses to build a release when the pushed git tag (`vX.Y.Z`) and the `Version` const in `internal/version/version.go` disagree.

```yaml
verify-version:
  steps:
    - extract X.Y.Z from $GITHUB_REF_NAME (strip leading 'v')
    - grep `Version = "..."` from internal/version/version.go
    - fail the workflow if mismatch, with an actionable error annotation
```

The existing `build → prepare-release / build-docker` chain transitively gains this guard via `needs:`, so a mismatch fails the workflow before any expensive step (matrix backend build, frontend build, multi-arch Docker push) starts.

## Why

Today's release pipeline takes the **version from the git tag** (it's what release.yml triggers on, and it's what shows up in artifact filenames + image tags) but `/hello`, `/healthz`, `ech0 version`, the About page, and `connect.Version` all read from `internal/version.Version` — a source-controlled const baked into the binary at build time.

Without this guard:

- Push tag `v4.7.0` while `version.go` still declares `4.6.4` → release workflow happily ships:
  - `ech0-linux-amd64.tar.gz` named after v4.7.0
  - Docker image `ech0:v4.7.0`
  - Binaries that report `4.6.4` from `/hello`, About page link points to v4.6.4 release notes, etc.

That's a high-confusion footgun for a self-hosted product where downstream operators (and AGPL §13 consumers) rely on the version string being honest.

This guard catches it in ~2 seconds of CI before any binary is produced.

## Verified locally

```
v4.6.4        + Version="4.6.4"      → pass
v4.7.0        + Version="4.6.4"      → fail (the bug we're catching)
v4.7.0-rc.1   + Version="4.7.0-rc.1" → pass (pre-release tags work)
```

The error annotation looks like:
```
::error title=Version mismatch::Git tag v4.7.0 → 4.7.0, but internal/version/version.go declares 4.6.4. Bump the const before tagging (see docs/dev/release-process.md).
```

## Notes

- The error message references `docs/dev/release-process.md`. That doc lands in the **next PR** (release-process docs + Makefile bump target). Until that PR merges, the link points at a not-yet-existing file — the actionable instruction in the error message ("Bump the const before tagging") still stands on its own.
- No change to existing build steps. The job is additive.
- Permissions unchanged — `verify-version` only does a checkout + greps a tracked file.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` → valid yaml
- [x] Local smoke test for matching, mismatching, and pre-release tags
- [ ] After merge: next time a real release tag is pushed, confirm `verify-version` job appears in Actions UI and runs in ~seconds
- [ ] (Optional one-off) Push a deliberately-wrong test tag like `v0.0.0-test` to confirm the guard fires in production CI, then delete the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)