### PR TITLE
chore: release process docs + make bump + CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable user-visible changes to Ech0 are recorded here.
+
+This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html), and this file follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+For releases prior to v4.6.5, see the [GitHub releases page](https://github.com/lin-snow/Ech0/releases) — earlier release notes are not retroactively imported here.
+
+## [Unreleased]
+
+### Added
+
+- **About page** (`/about`) reachable from the homepage banner. Displays the running instance's version, commit hash, build time, license, copyright, author, and a source-code link pinned to the exact commit. Implements AGPL-3.0 §13 (network users may obtain the corresponding source).
+- **`internal/version` package** as the single source of truth for build / release metadata (Version, License, Author, RepoURL, StartYear, plus ldflags-injected Commit and BuildTime). Replaces the version constant that used to live in `internal/model/common`.
+- **`make bump NEW_VERSION=X.Y.Z`** target that prepares a clean version-bump commit (does not auto-commit or tag).
+- **CI guardrail**: the release workflow now refuses to build when the pushed git tag (`vX.Y.Z`) and `internal/version.Version` disagree. Prevents publishing artifacts that lie about their own version.
+- **SPDX / Copyright headers** on every `.go` / `.ts` / `.vue` source file, plus a maintenance script `scripts/add-spdx-headers.mjs` (write / `--dry-run` / `--check` modes).
+- **`docs/dev/release-process.md`** documenting the standard release procedure.
+
+### Changed
+
+- **`/api/hello` response shape**: dropped the legacy `github` field; added `commit`, `build_time`, `license`, `author`, `repo_url`, and `copyright`. The frontend reads version metadata from this endpoint instead of hardcoding it. Pre-PR consumers of the `github` field should switch to `repo_url` (no in-tree consumer existed).
+- **`web/package.json`** now declares `license`, `author`, and `homepage` so npm tooling and SPDX scanners pick up project licensing without parsing the repo.
+
+### Security
+
+- Pinned `serialize-javascript` to `^7.0.5` in `hub/pnpm-lock.yaml` via `pnpm.overrides`, clearing two Dependabot alerts:
+  - [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) — RCE via `RegExp.flags` and `Date.prototype.toISOString` (HIGH)
+  - [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) — CPU-exhaustion DoS via crafted array-like objects (MEDIUM)
+
+  Practical risk in this repo was negligible (the vulnerable code only runs at PWA build time on developer-controlled input), but the alerts are now resolved at the supply-chain level.
+
+[Unreleased]: https://github.com/lin-snow/Ech0/compare/v4.6.4...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,10 @@ Your PR description should include:
 
 For large changes, consider splitting into smaller, reviewable PRs.
 
+## Releasing
+
+Maintainers cutting a new release should follow the documented procedure in [`docs/dev/release-process.md`](docs/dev/release-process.md). User-visible changes per release are tracked in [`CHANGELOG.md`](CHANGELOG.md); add an entry under `[Unreleased]` whenever your PR introduces a change a self-hoster needs to know about.
+
 ## Code style
 
 - Match existing project style and layout; avoid introducing patterns that conflict with current conventions.

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ IMAGE_TAG?=latest
 OS?=$(if $(GOHOSTOS),$(GOHOSTOS),linux)
 ARCH?=$(if $(GOHOSTARCH),$(GOHOSTARCH),amd64)
 
-.PHONY: help air-install run dev web-dev check dev-lint lint fmt test wire wire-check swagger build build-image push-image
+.PHONY: help air-install run dev web-dev check dev-lint lint fmt test wire wire-check swagger build bump build-image push-image
+
+# Semver pattern: X.Y.Z, optionally followed by a -prerelease suffix.
+# (escape $ so make doesn't expand, then escape $$ to a literal $ in shell)
+SEMVER_PATTERN := ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$$
 
 AIR_BIN := $(shell command -v air 2>/dev/null || echo "$(GOPATH)/bin/air")
 
@@ -29,6 +33,8 @@ help:
 	@echo "  make air-install - Install Air to GOPATH/bin"
 	@echo "  make web-dev     - Run frontend dev server"
 	@echo "  make build       - Build local binary with version/commit injected"
+	@echo "  make bump NEW_VERSION=X.Y.Z"
+	@echo "                   - Bump internal/version.Version + sanity-check (does NOT commit/tag)"
 	@echo "  make check       - Backend fmt/lint + web format/lint + i18n checks"
 	@echo "  make dev-lint    - Backend fmt/lint + web format/lint + i18n checks"
 	@echo "  make lint        - Run golangci-lint checks"
@@ -48,6 +54,53 @@ run:
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o ./bin/ech0 ./cmd/ech0
+
+# Prepare a clean version-bump commit. This target only EDITS files —
+# it never auto-commits, never tags, never pushes. The next-step commands
+# are printed for the developer to run after eyeballing the diff.
+# See docs/dev/release-process.md for the full procedure.
+bump:
+	@if [ -z "$(NEW_VERSION)" ]; then \
+		echo "✘ Usage: make bump NEW_VERSION=X.Y.Z"; \
+		echo "  e.g. make bump NEW_VERSION=4.6.5"; \
+		exit 1; \
+	fi
+	@echo "$(NEW_VERSION)" | grep -Eq '$(SEMVER_PATTERN)' \
+		|| { echo "✘ '$(NEW_VERSION)' is not valid semver (expected X.Y.Z[-prerelease])"; exit 1; }
+	@if [ -n "$$(git status --porcelain)" ]; then \
+		echo "✘ Working tree dirty — commit or stash first so the bump commit is clean."; \
+		git status --short; \
+		exit 1; \
+	fi
+	@OLD_VERSION="$$(grep -E '^[[:space:]]*Version[[:space:]]*=[[:space:]]*\"' internal/version/version.go \
+	                  | head -n1 \
+	                  | sed -E 's/.*\"([^\"]+)\".*/\1/')"; \
+	if [ -z "$$OLD_VERSION" ]; then \
+		echo "✘ Could not extract current Version from internal/version/version.go"; \
+		exit 1; \
+	fi; \
+	if [ "$$OLD_VERSION" = "$(NEW_VERSION)" ]; then \
+		echo "✘ Version is already $$OLD_VERSION — nothing to bump."; \
+		exit 1; \
+	fi; \
+	echo "→ bumping $$OLD_VERSION → $(NEW_VERSION)"; \
+	sed -i.bak -E 's/^([[:space:]]*Version[[:space:]]*=[[:space:]]*\")[^\"]+(\")/\1$(NEW_VERSION)\2/' internal/version/version.go; \
+	rm -f internal/version/version.go.bak
+	@echo "→ verifying go build still succeeds..."
+	@go build ./... >/dev/null || { echo "✘ go build failed after bump — reverting"; git checkout -- internal/version/version.go; exit 1; }
+	@echo ""
+	@echo "✓ Version bumped. Diff:"
+	@git --no-pager diff -- internal/version/version.go
+	@echo ""
+	@echo "Next steps (review the diff above, then run):"
+	@echo ""
+	@echo "  # 1. Update CHANGELOG.md: rename [Unreleased] → [$(NEW_VERSION)] - $$(date -u +%Y-%m-%d), open a new empty [Unreleased]"
+	@echo "  # 2. Commit + tag:"
+	@echo "       git commit -am 'chore(release): v$(NEW_VERSION)'"
+	@echo "       git tag -a v$(NEW_VERSION) -m 'Release v$(NEW_VERSION)'"
+	@echo "  # 3. Push to trigger release workflow:"
+	@echo "       git push origin main"
+	@echo "       git push origin v$(NEW_VERSION)"
 
 dev:
 	@if [ ! -x "$(AIR_BIN)" ]; then \

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -1,0 +1,186 @@
+# Release Process
+
+This document describes how to cut a new release of Ech0.
+
+## TL;DR
+
+```bash
+# starting from a clean tree on main, in sync with origin
+make check                                              # full pre-release lint pass
+make bump NEW_VERSION=4.6.5                             # edits internal/version/version.go
+$EDITOR CHANGELOG.md                                    # rename [Unreleased] → [4.6.5] - YYYY-MM-DD; add a fresh empty [Unreleased]
+git commit -am 'chore(release): v4.6.5'
+git tag -a v4.6.5 -m 'Release v4.6.5'
+git push origin main v4.6.5                             # tag push triggers .github/workflows/release.yml
+gh release view v4.6.5                                  # verify artifacts after CI completes
+```
+
+The rest of this document explains *why* each step exists and how to handle edge cases.
+
+## Versioning
+
+Ech0 follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html):
+
+- **MAJOR** (`X.Y.Z` → `(X+1).0.0`) — breaking changes to the API, auth model, storage layout, config keys, or anything else self-hosted operators rely on. Requires migration notes in CHANGELOG.
+- **MINOR** (`X.Y.Z` → `X.(Y+1).0`) — backwards-compatible new features.
+- **PATCH** (`X.Y.Z` → `X.Y.(Z+1)`) — backwards-compatible bug fixes.
+
+Pre-release tags (`v5.0.0-rc.1`, `v5.0.0-beta.1`) are used for major bumps where you want real users to test before the stable promotion. The `internal/version.Version` const must include the suffix verbatim (`Version = "5.0.0-rc.1"`) — the CI guard verifies this.
+
+## The single source of truth
+
+The version is declared **once** in [`internal/version/version.go`](../../internal/version/version.go):
+
+```go
+const (
+    Version = "4.6.4"
+    ...
+)
+```
+
+Everywhere else (`/hello`, `/healthz`, the About page, `ech0 version`, `ech0 info`, MCP server identification, connect federation) reads from this single const. Build-time metadata (`Commit`, `BuildTime`) is injected via `-ldflags -X` from the Makefile / Dockerfile / release workflow.
+
+**Never edit the version string in any other file.** If you find a hardcoded version anywhere, that is a bug to fix, not a place to also bump.
+
+## Pre-release sanity
+
+Before bumping the version, make sure the working state is releasable:
+
+1. **Clean tree on `main`, in sync with origin.**
+   ```bash
+   git checkout main
+   git pull --ff-only
+   git status   # must be empty
+   ```
+
+2. **All recently-merged PRs have CI green on `main`.** Check the Actions tab.
+
+3. **Full local check passes.**
+   ```bash
+   make check   # backend fmt/lint + swagger drift check + web format/lint/i18n/style
+   go test ./...
+   pnpm -C web test:unit   # if you've changed anything frontend
+   ```
+
+4. **Decide the new version.** Look through merged PRs since the last tag; the highest-impact change determines the bump (breaking → MAJOR, feature → MINOR, fix → PATCH).
+
+   ```bash
+   git log v4.6.4..HEAD --oneline   # everything since the last release
+   ```
+
+## Bumping the version
+
+```bash
+make bump NEW_VERSION=4.6.5
+```
+
+This target:
+
+- Validates `NEW_VERSION` is set and matches semver (`X.Y.Z` or `X.Y.Z-prerelease`).
+- Refuses to run when the working tree is dirty (otherwise the release commit would carry unrelated drift).
+- Edits `internal/version/version.go` to the new value.
+- Runs `go build ./...` as a sanity check; reverts the file automatically if the build fails.
+- Prints the diff plus the next-step commands to run.
+
+`make bump` **never** auto-commits, never tags, never pushes — those are deliberate human actions. Eyeball the diff before proceeding.
+
+## Updating CHANGELOG.md
+
+Every release commit updates [`CHANGELOG.md`](../../CHANGELOG.md) atomically with the version bump:
+
+1. Rename the existing `## [Unreleased]` heading to `## [X.Y.Z] - YYYY-MM-DD` (UTC date).
+2. Open a new empty `## [Unreleased]` section above it (with empty `### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security` sub-headings as you need them — don't include empty sections in the published version, but keep the template at the top for the next dev cycle).
+3. Update the link references at the bottom:
+   ```
+   [Unreleased]: https://github.com/lin-snow/Ech0/compare/v4.6.5...HEAD
+   [4.6.5]: https://github.com/lin-snow/Ech0/compare/v4.6.4...v4.6.5
+   ```
+
+CHANGELOG entries should be written for **users / operators**, not developers. Prefer:
+
+- ✓ "Added: Per-user storage quotas configurable via `STORAGE_QUOTA_MB`."
+- ✗ "Refactored storage middleware in `internal/middleware/staticfile.go` to support quota injection."
+
+The latter belongs in commit messages, not the user-facing CHANGELOG.
+
+## Committing and tagging
+
+```bash
+git commit -am 'chore(release): vX.Y.Z'
+git tag -a vX.Y.Z -m 'Release vX.Y.Z'
+```
+
+- Commit message format is exactly `chore(release): vX.Y.Z` (lowercase `v`, no extra punctuation). This makes `git log --grep 'chore(release)'` a clean release ledger.
+- Use **annotated** tags (`-a`), not lightweight ones — annotated tags carry author, date, and message, and are first-class objects.
+- If you have a GPG or SSH signing key configured, use `git tag -s` instead. GitHub will display a "Verified" badge on signed tags, which lets downstream operators distinguish authentic releases from impersonations.
+
+The tag must point at the same commit that contains the bump (i.e. tag immediately after committing). The CI guard refuses to build a release where the tag and `version.go` disagree.
+
+## Pushing and triggering the release
+
+```bash
+git push origin main         # publish the chore(release) commit
+git push origin vX.Y.Z       # push the tag separately to trigger release.yml
+```
+
+Pushing the tag is the act that commits to the release publicly:
+
+- [`.github/workflows/release.yml`](../../.github/workflows/release.yml) fires on `tags: v*`.
+- `verify-version` runs first; if `Version != tag`, the workflow fails fast.
+- `build` then produces `linux/amd64` and `linux/arm64` static binaries with `Commit` and `BuildTime` ldflags-injected.
+- `prepare-release` packages them as `tar.gz` and creates a **draft** GitHub release.
+- `build-docker` pushes multi-arch images to GHCR and Docker Hub, tagged `vX.Y.Z` and `latest`.
+
+After the workflow completes:
+
+1. **Verify the artifacts.**
+   ```bash
+   gh release view vX.Y.Z              # check files, draft status
+   gh run watch                        # if still running
+   ```
+   Download the linux/amd64 binary, run `./ech0 version` and `./ech0 info`, sanity-check that the version + commit hash match what you tagged.
+
+2. **Promote the draft release to published.** GitHub release notes default to auto-generated PR titles since the last release; replace them with the relevant `[X.Y.Z]` section from `CHANGELOG.md`.
+
+3. **Pull the Docker image** to confirm:
+   ```bash
+   docker pull ghcr.io/lin-snow/ech0:vX.Y.Z
+   docker run --rm ghcr.io/lin-snow/ech0:vX.Y.Z version
+   ```
+
+## Hot-fix releases
+
+If a critical bug is discovered post-release:
+
+1. Branch off the affected tag: `git checkout -b fix/<short-name> vX.Y.Z`.
+2. Apply the minimal fix; merge to `main` via PR.
+3. From `main`, follow the standard procedure with a PATCH bump (`vX.Y.(Z+1)`).
+4. Do **not** re-tag the original release — published tags are immutable.
+
+## Pre-release / RC tags
+
+For breaking changes you want validated before stable:
+
+```bash
+make bump NEW_VERSION=5.0.0-rc.1
+# ... commit / tag / push as v5.0.0-rc.1
+```
+
+GitHub will mark the release as "pre-release" if the workflow detects the suffix (currently this is on by default in the `softprops/action-gh-release` step's `prerelease: false` flag — flip to `prerelease: true` for RC tags, or auto-detect by tag suffix in a future improvement).
+
+After the RC bakes in real environments for a week or two, promote with a stable tag:
+
+```bash
+make bump NEW_VERSION=5.0.0
+# ... commit / tag / push as v5.0.0
+```
+
+## Future improvements (not implemented yet)
+
+These are options you might want as the project grows; they are deliberately not adopted today to keep the release surface simple for a single-maintainer project.
+
+- **[release-please](https://github.com/googleapis/release-please)** — a GitHub Action that watches `feat:` / `fix:` / `chore(deps):` commits, decides the next version automatically, and opens a "Release vX.Y.Z" PR. Merging that PR auto-tags. Would replace `make bump` + manual CHANGELOG editing with a fully automated PR-based flow.
+- **[git-cliff](https://github.com/orhun/git-cliff)** — auto-generates CHANGELOG from conventional commits without taking over the tag-creation step.
+- **Reproducible builds** via `SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)` instead of `date -u +%Y-%m-%dT%H:%M:%SZ` for `BuildTime`. Two builds of the same commit would then produce byte-identical binaries.
+- **Signed tags by default** in CI (sigstore / cosign signatures on artifacts and images).
+- **Auto-generated SBOM** alongside release artifacts.


### PR DESCRIPTION
## Summary

Establishes a reproducible release procedure on top of the version-metadata work merged in #244 and the CI guard proposed in #246.

Three new pieces, each focused:

### 1. `make bump NEW_VERSION=X.Y.Z`

A Makefile target that prepares a clean version-bump commit. It:

- validates `NEW_VERSION` is set and matches semver (`X.Y.Z` or `X.Y.Z-prerelease`),
- refuses to run when the working tree is dirty (otherwise the release commit would carry unrelated drift),
- edits `internal/version/version.go` (the single source of truth),
- runs `go build ./...` as a sanity check; reverts the file automatically if the build breaks,
- prints the diff and the next-step commands.

It deliberately **never auto-commits, never tags, never pushes** — those remain explicit human actions. The whole point is for the bump commit to be reviewable before it ships.

Smoke-tested for: missing arg, bad semver (`4.6` rejected), dirty tree refusal, `v`-prefix rejection (user passes `4.6.5` not `v4.6.5`), and pre-release suffix (`5.0.0-rc.1`).

### 2. `CHANGELOG.md`

[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format. The first `[Unreleased]` section already catalogs the user-visible changes merged since v4.6.4:

- About page + `internal/version` extraction + ldflags injection (#244)
- SPDX/Copyright headers across the codebase (#244)
- `serialize-javascript` security pin (#245)
- CI tag/version guard (#246)
- This PR's release tooling

Releases prior to v4.6.5 are **not** retroactively imported — the file references the existing GitHub releases page for history. That's a deliberate choice: backfilling 10+ tags of "user-visible vs. internal" triage isn't worth the effort, and operators looking for old release notes already know to check the releases tab.

### 3. `docs/dev/release-process.md`

Top-to-bottom procedure for cutting a release. Sections:

- TL;DR (the 7-command happy path)
- Versioning (semver rules, when to bump major/minor/patch, RC tags)
- Single source of truth (why version lives in exactly one file)
- Pre-release sanity (clean tree, on main, in sync, `make check`, `go test`)
- Bumping the version
- Updating CHANGELOG.md (rename `[Unreleased]` → `[X.Y.Z] - date`, open new empty `[Unreleased]`, update link refs)
- Committing and tagging (annotated tags, signing, exact commit-message format)
- Pushing and triggering the release (what `release.yml` does post-tag)
- Hot-fix releases (branch from tag, minimal fix, PATCH bump)
- Pre-release / RC tags
- Future improvements (release-please, git-cliff, reproducible builds, signed tags, SBOM) — explicitly NOT adopted today, listed as a roadmap if the project outgrows the manual flow

`CONTRIBUTING.md` gets a new "Releasing" subsection that links to the doc, plus a reminder that user-visible PRs should add an `[Unreleased]` entry.

## Sequencing notes

This PR depends on neither #245 (deps fix) nor #246 (CI guard) for correctness — `make bump` and the docs work standalone — but it **assumes** #246 will land, because the docs reference the CI guard ("If `Version != tag`, the workflow fails fast"). If #246 is held, this PR's docs are mildly aspirational on that point but still accurate for the manual procedure.

Recommended merge order: #245 → #246 → this.

## Test plan

- [x] `make help` shows `make bump` with usage hint
- [x] `make bump` (no arg) → usage error, exit 1
- [x] `make bump NEW_VERSION=4.6` → "not valid semver", exit 1
- [x] `make bump NEW_VERSION=v4.6.5` → "not valid semver", exit 1 (user must omit `v`)
- [x] `make bump NEW_VERSION=4.6.5` from dirty tree → refusal with `git status` output, exit 1
- [x] sed pattern verified manually: `Version = "4.6.4"` → `Version = "4.6.5"` (tab indentation preserved)
- [x] Semver regex matches `4.6.5`, `5.0.0-rc.1`, `5.0.0-beta.2`; rejects `4.6`, `v4.6.5`
- [ ] Manual: actually run a full `make bump` end-to-end on a real upcoming release (will validate during the next bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)