### PR TITLE
feat(web): redesign about page and add icon entry on home banner

### DIFF
--- a/web/src/components/icons/exclamation.vue
+++ b/web/src/components/icons/exclamation.vue
@@ -1,0 +1,10 @@
+
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><!-- Icon from Tabler Icons by Paweł Kuna - https://github.com/tabler/tabler-icons/blob/master/LICENSE --><path fill="none" stroke="#888888" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9h.01M11 12h1v4h1" /></svg>
+</template>
+
+<script lang="ts">
+export default {
+  name: 'TablerInfoSmall'
+}
+</script>

--- a/web/src/locales/messages/de-DE.json
+++ b/web/src/locales/messages/de-DE.json
@@ -908,16 +908,13 @@
   },
   "about": {
     "linkAriaLabel": "Über diese Ech0-Instanz",
-    "tagline": "Eine selbst gehostete, leichtgewichtige Publishing-Plattform für deine Gedanken.",
     "copyrightHeading": "Urheberrecht",
     "licenseLine": "Veröffentlicht unter der",
-    "agplNotice": "Als Netzwerkdienst folgt Ech0 der AGPL-3.0 §13: Nutzer, die mit dieser Instanz interagieren, haben Anspruch auf den entsprechenden Quellcode.",
     "authorHeading": "Autor",
     "authorGithub": "GitHub-Profil",
     "sourceHeading": "Quellcode",
-    "sourceDescription": "Der vollständige Quellcode von Ech0 ist auf GitHub öffentlich verfügbar.",
     "viewSource": "Quellcode auf GitHub ansehen",
-    "viewSourceAtCommit": "Quellcode @ {commit} auf GitHub ansehen",
+    "viewSourceAtCommit": "Quellcode {'@'} {commit} auf GitHub ansehen",
     "viewRelease": "Release-Notes für v{version}",
     "buildTime": "Gebaut am {time}",
     "poweredBy": "Mit Sorgfalt gebaut · Powered by Ech0"

--- a/web/src/locales/messages/en-US.json
+++ b/web/src/locales/messages/en-US.json
@@ -908,16 +908,13 @@
   },
   "about": {
     "linkAriaLabel": "About this Ech0 instance",
-    "tagline": "A self-hosted, lightweight publishing platform for your thoughts.",
     "copyrightHeading": "Copyright",
     "licenseLine": "Released under the",
-    "agplNotice": "As a network service, Ech0 follows AGPL-3.0 §13: users interacting with this instance are entitled to receive its corresponding source code.",
     "authorHeading": "Author",
     "authorGithub": "GitHub Profile",
     "sourceHeading": "Source Code",
-    "sourceDescription": "The full source code of Ech0 is publicly available on GitHub.",
     "viewSource": "View source on GitHub",
-    "viewSourceAtCommit": "View source @ {commit} on GitHub",
+    "viewSourceAtCommit": "View source {'@'} {commit} on GitHub",
     "viewRelease": "Release notes for v{version}",
     "buildTime": "Built {time}",
     "poweredBy": "Built with care · Powered by Ech0"

--- a/web/src/locales/messages/ja-JP.json
+++ b/web/src/locales/messages/ja-JP.json
@@ -908,16 +908,13 @@
   },
   "about": {
     "linkAriaLabel": "この Ech0 インスタンスについて",
-    "tagline": "セルフホスト型の軽量パブリッシングプラットフォーム。",
     "copyrightHeading": "著作権",
     "licenseLine": "本ソフトウェアは",
-    "agplNotice": "ネットワークサービスとして、Ech0 は AGPL-3.0 第 13 条に従います：本インスタンスを利用するユーザーは、対応するソースコードを取得する権利を有します。",
     "authorHeading": "作者",
     "authorGithub": "GitHub プロフィール",
     "sourceHeading": "ソースコード",
-    "sourceDescription": "Ech0 の完全なソースコードは GitHub で公開されています。",
     "viewSource": "GitHub でソースを見る",
-    "viewSourceAtCommit": "GitHub で commit @ {commit} のソースを見る",
+    "viewSourceAtCommit": "GitHub で commit {'@'} {commit} のソースを見る",
     "viewRelease": "v{version} リリースノート",
     "buildTime": "ビルド時刻 {time}",
     "poweredBy": "心を込めて · Powered by Ech0"

--- a/web/src/locales/messages/zh-CN.json
+++ b/web/src/locales/messages/zh-CN.json
@@ -908,16 +908,13 @@
   },
   "about": {
     "linkAriaLabel": "关于本 Ech0 实例",
-    "tagline": "一个自托管的轻量级个人发布平台。",
     "copyrightHeading": "版权",
     "licenseLine": "本软件以",
-    "agplNotice": "作为网络服务，Ech0 遵循 AGPL-3.0 第 13 条：与本实例交互的用户有权获取其对应版本的源代码。",
     "authorHeading": "作者",
     "authorGithub": "GitHub 主页",
     "sourceHeading": "源代码",
-    "sourceDescription": "Ech0 的完整源代码在 GitHub 上公开可用。",
     "viewSource": "在 GitHub 上查看源代码",
-    "viewSourceAtCommit": "在 GitHub 上查看 commit @ {commit} 的源代码",
+    "viewSourceAtCommit": "在 GitHub 上查看 commit {'@'} {commit} 的源代码",
     "viewRelease": "v{version} 发布说明",
     "buildTime": "构建时间 {time}",
     "poweredBy": "用心打造 · Powered by Ech0"

--- a/web/src/views/about/modules/AboutPage.vue
+++ b/web/src/views/about/modules/AboutPage.vue
@@ -2,29 +2,85 @@
 <!-- Copyright (C) 2025-2026 lin-snow -->
 <template>
   <div class="about-page">
-    <div class="about-shell">
-      <header class="about-header">
-        <BaseButton
-          @click="$router.push({ name: 'home' })"
-          :tooltip="t('commonNav.backHome')"
-          class="about-back"
-        >
-          <Arrow class="text-2xl rotate-180" />
-        </BaseButton>
-        <div class="about-title">
-          <h1 class="about-title__name">Ech0</h1>
-          <span class="about-title__version">
-            v{{ version }}
-            <span v-if="hasCommit" class="about-title__commit"> · {{ commit }}</span>
-          </span>
+    <div class="about-back-wrap">
+      <BaseButton
+        @click="$router.push({ name: 'home' })"
+        :tooltip="t('commonNav.backHome')"
+      >
+        <Arrow class="text-2xl rotate-180" />
+      </BaseButton>
+    </div>
+
+    <article class="about-shell">
+      <header class="about-hero">
+        <h1 class="about-hero__name">Ech0</h1>
+        <div class="about-hero__meta">
+          <span class="about-hero__version">v{{ version }}</span>
+          <span v-if="hasCommit" class="about-hero__sep" aria-hidden="true">·</span>
+          <span v-if="hasCommit" class="about-hero__commit">{{ commit }}</span>
         </div>
-        <p class="about-title__tagline">{{ t('about.tagline') }}</p>
       </header>
 
-      <section class="about-card">
-        <h2 class="about-card__heading">{{ t('about.copyrightHeading') }}</h2>
-        <p class="about-card__text">{{ copyright }}</p>
-        <p class="about-card__text about-card__text--muted">
+      <hr class="about-rule" />
+
+      <section class="about-section">
+        <h2 class="about-section__heading">{{ t('about.authorHeading') }}</h2>
+        <p class="about-section__line">
+          <span class="about-section__value">{{ author }}</span>
+          <a
+            :href="AUTHOR_GITHUB"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="about-chip"
+          >
+            <Github class="about-chip__icon" />
+            <span>{{ t('about.authorGithub') }}</span>
+          </a>
+        </p>
+      </section>
+
+      <hr class="about-rule" />
+
+      <section class="about-section">
+        <h2 class="about-section__heading">{{ t('about.sourceHeading') }}</h2>
+        <ul class="about-list">
+          <li>
+            <a
+              :href="sourceURL"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="about-chip"
+              :aria-label="sourceLinkLabel"
+              :title="sourceLinkLabel"
+            >
+              <Github class="about-chip__icon" />
+              <span v-if="hasCommit" class="about-chip__commit">{{ commit }}</span>
+              <span v-else>{{ t('about.viewSource') }}</span>
+            </a>
+          </li>
+          <li v-if="version && version !== '--'">
+            <a
+              :href="`${repoURL}/releases/tag/v${version}`"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="about-chip"
+            >
+              <Info class="about-chip__icon" />
+              <span>{{ t('about.viewRelease', { version }) }}</span>
+            </a>
+          </li>
+        </ul>
+        <p v-if="buildTime" class="about-section__build">
+          {{ t('about.buildTime', { time: buildTime }) }}
+        </p>
+      </section>
+
+      <hr class="about-rule" />
+
+      <section class="about-section">
+        <h2 class="about-section__heading">{{ t('about.copyrightHeading') }}</h2>
+        <p class="about-section__line">{{ copyright }}</p>
+        <p class="about-section__line about-section__line--muted">
           {{ t('about.licenseLine') }}
           <a
             :href="`${repoURL}/blob/main/LICENSE`"
@@ -35,62 +91,14 @@
             {{ license }}
           </a>
         </p>
-        <p class="about-card__text about-card__text--muted">
-          {{ t('about.agplNotice') }}
-        </p>
-      </section>
-
-      <section class="about-card">
-        <h2 class="about-card__heading">{{ t('about.authorHeading') }}</h2>
-        <p class="about-card__text">{{ author }}</p>
-        <div class="about-links">
-          <a
-            :href="AUTHOR_GITHUB"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="about-link about-link--row"
-          >
-            <Github class="about-link__icon" />
-            <span>{{ t('about.authorGithub') }}</span>
-          </a>
-        </div>
-      </section>
-
-      <section class="about-card">
-        <h2 class="about-card__heading">{{ t('about.sourceHeading') }}</h2>
-        <p class="about-card__text about-card__text--muted">
-          {{ t('about.sourceDescription') }}
-        </p>
-        <div class="about-links">
-          <a
-            :href="sourceURL"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="about-link about-link--row"
-          >
-            <Github class="about-link__icon" />
-            <span>{{ sourceLinkLabel }}</span>
-          </a>
-          <a
-            v-if="version && version !== '--'"
-            :href="`${repoURL}/releases/tag/v${version}`"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="about-link about-link--row"
-          >
-            <Info class="about-link__icon" />
-            <span>{{ t('about.viewRelease', { version }) }}</span>
-          </a>
-          <p v-if="buildTime" class="about-card__text about-card__text--muted about-build-time">
-            {{ t('about.buildTime', { time: buildTime }) }}
-          </p>
-        </div>
       </section>
 
       <footer class="about-footer">
+        <span class="about-footer__mark" aria-hidden="true">·</span>
         <span>{{ t('about.poweredBy') }}</span>
+        <span class="about-footer__mark" aria-hidden="true">·</span>
       </footer>
-    </div>
+    </article>
   </div>
 </template>
 
@@ -138,149 +146,216 @@ const sourceLinkLabel = computed(() =>
 
 <style scoped>
 .about-page {
+  position: relative;
   display: flex;
   justify-content: center;
   width: 100%;
   min-height: 100vh;
-  padding: 1.5rem 1rem 4rem;
+  padding: 2.5rem 1.25rem 4rem;
+}
+
+.about-back-wrap {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  z-index: 1;
 }
 
 .about-shell {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
   width: 100%;
-  max-width: 42rem;
+  max-width: 36rem;
+  padding: 1rem 0.25rem;
 }
 
-.about-header {
-  position: relative;
+.about-hero {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
-  padding: 2rem 1rem 1rem;
+  gap: 0.55rem;
+  padding: 1.5rem 0 0.75rem;
   text-align: center;
 }
 
-.about-back {
-  position: absolute;
-  top: 0.5rem;
-  left: 0;
-  border-radius: var(--radius-xs);
-}
-
-.about-title {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-}
-
-.about-title__name {
+.about-hero__name {
   margin: 0;
   font-family: var(--font-family-display);
-  font-size: 2rem;
+  font-size: 2.5rem;
   font-weight: 700;
+  letter-spacing: -0.01em;
   color: var(--color-text-primary);
 }
 
-.about-title__version {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-}
-
-.about-title__commit {
-  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, monospace);
-  font-weight: 500;
+.about-hero__meta {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: 0.8125rem;
   color: var(--color-text-muted);
 }
 
-.about-title__tagline {
-  margin: 0;
+.about-hero__version {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.about-hero__sep {
+  opacity: 0.6;
+}
+
+.about-hero__commit {
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.about-hero__tagline {
+  margin: 0.25rem 0 0;
+  font-family: 'Songti SC', STSong, var(--font-family-display);
   font-size: 0.9375rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
   color: var(--color-text-secondary);
 }
 
-.about-card {
+.about-rule {
+  width: 100%;
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--color-text-muted);
+  opacity: 0.18;
+}
+
+.about-section {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  padding: 1rem 1.125rem;
-  background: var(--color-bg-surface);
-  border-radius: var(--radius-xs);
-  box-shadow: var(--shadow-soft);
+  padding: 0 0.25rem;
 }
 
-.about-card__heading {
-  margin: 0 0 0.25rem;
-  font-size: 0.8125rem;
+.about-section__heading {
+  margin: 0 0 0.15rem;
+  font-size: 0.6875rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
 
-.about-card__text {
+.about-section__line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
   margin: 0;
   font-size: 0.9375rem;
-  line-height: 1.55;
+  line-height: 1.6;
   color: var(--color-text-primary);
 }
 
-.about-card__text--muted {
-  font-size: 0.875rem;
+.about-section__line--muted {
   color: var(--color-text-secondary);
+  font-size: 0.875rem;
 }
 
-.about-links {
+.about-section__value {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.about-section__build {
+  margin: 0.15rem 0 0;
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.about-list {
   display: flex;
   flex-direction: column;
-  gap: 0.375rem;
-  margin-top: 0.25rem;
+  gap: 0.4rem;
+  margin: 0.15rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.about-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  background: transparent;
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--color-text-muted) 30%, transparent);
+  transition:
+    color 0.15s ease,
+    background 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.about-chip:hover {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--color-accent) 35%, transparent);
+}
+
+.about-chip__icon {
+  font-size: 0.95rem;
+  color: currentColor;
+}
+
+.about-chip:hover .about-chip__icon {
+  color: currentColor;
+}
+
+.about-chip__commit {
+  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
 }
 
 .about-link {
   color: var(--color-text-primary);
   text-decoration: underline;
-  text-decoration-color: var(--color-text-muted);
-  text-underline-offset: 0.2em;
+  text-decoration-color: color-mix(in oklab, var(--color-text-muted) 60%, transparent);
+  text-underline-offset: 0.22em;
   transition: text-decoration-color 0.15s ease;
 }
 
 .about-link:hover {
-  text-decoration-color: var(--color-text-primary);
-}
-
-.about-link--row {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  text-decoration: none;
-  font-size: 0.9375rem;
-}
-
-.about-link--row:hover .about-link__icon {
-  color: var(--color-text-primary);
-}
-
-.about-link__icon {
-  font-size: 1.125rem;
-  color: var(--color-text-secondary);
-  transition: color 0.15s ease;
-}
-
-.about-build-time {
-  margin-top: 0.25rem;
-  font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
+  text-decoration-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .about-footer {
-  margin-top: 0.5rem;
-  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  margin-top: 1rem;
+  font-family: 'Songti SC', STSong, var(--font-family-display);
   font-size: 0.75rem;
+  letter-spacing: 0.06em;
   color: var(--color-text-muted);
+  text-align: center;
+}
+
+.about-footer__mark {
+  opacity: 0.5;
+}
+
+@media (width <= 480px) {
+  .about-page {
+    padding: 2rem 0.75rem 3rem;
+  }
+
+  .about-hero__name {
+    font-size: 2.125rem;
+  }
 }
 </style>

--- a/web/src/views/home/modules/HomeBanner.vue
+++ b/web/src/views/home/modules/HomeBanner.vue
@@ -13,6 +13,14 @@
       >
         Powered by Ech0
       </RouterLink>
+      <RouterLink
+        :to="{ name: 'about' }"
+        class="home-banner__about"
+        :aria-label="t('about.linkAriaLabel')"
+        :title="t('about.linkAriaLabel')"
+      >
+        <Exclamation class="home-banner__about-icon" />
+      </RouterLink>
     </div>
   </section>
 </template>
@@ -20,6 +28,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { RouterLink } from 'vue-router'
+import Exclamation from '@/components/icons/exclamation.vue'
 const { t } = useI18n()
 </script>
 
@@ -82,5 +91,36 @@ const { t } = useI18n()
 
 .home-banner__powered:hover {
   color: var(--color-text-primary);
+}
+
+.home-banner__about {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  outline: none;
+  transition:
+    color 0.15s ease,
+    transform 0.15s ease;
+}
+
+.home-banner__about:hover {
+  color: var(--color-accent);
+  transform: translateY(-1px);
+}
+
+.home-banner__about:focus-visible {
+  color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-soft);
+}
+
+.home-banner__about-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  font-size: 2.5rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- **HomeBanner**: add an exclamation icon in the bottom-right as an extra About entry. The existing "Powered by Ech0" link is preserved.
- **About page redesign**: drop the white card containers; centered narrow column on the canvas background with hairline dividers, pill-style chips for actionable links, manuscript-style footer.
- **Compact source chip**: when a commit hash is known, the source-code chip shows only the hash in monospace; full description kept as `aria-label` / `title` so screen readers and tooltips still get the long form. Avoids ugly wrapping on mobile.
- **Trim copy**: remove `about.tagline`, `about.sourceDescription`, and `about.agplNotice` from the page and from all four locale files.
- **Bug fix — i18n compile error**: the message `View source @ {commit} on GitHub` (and zh/ja/de equivalents) was throwing `Invalid linked format` at render time. vue-i18n treats `@` as the linked-messages prefix, so what followed was being parsed as a key path. Escaped using `{'@'}` literal interpolation in all four locales.
- **Bug fix — back-button layout shift**: `BaseButton` is wrapped by `BaseTooltip` (`floating-vue`'s `<VTooltip>`), which adds an outer wrapper element. Putting `position: absolute` on the inner button left the wrapper occupying a flex slot in `.about-page`, pushing the centered `.about-shell` to the right. Wrapped the button in a `<div class="about-back-wrap">` and absolutely-positioned the wrapper instead.

## Test plan
- [ ] `make check` (backend + web lint + i18n)
- [ ] `pnpm -C web build` succeeds
- [ ] Home page: exclamation icon visible at the bottom-right of the banner; both it and "Powered by Ech0" route to `/about`
- [ ] About page: no white card boxes; sections separated by subtle hairlines; back button does not shift the shell layout
- [ ] About page on a narrow viewport (≤ 420px wide): source-code chip stays on one line
- [ ] Switch locales (en/zh/ja/de): no console errors from i18n compilation; chip text and aria-label render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)