### PR TITLE
chore(deps): bump @dicebear/core to 10 + migrate to @dicebear/styles (supersedes #274)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@cap.js/widget": "^0.1.53",
-    "@dicebear/core": "^9.4.2",
-    "@dicebear/micah": "^9.4.2",
+    "@dicebear/core": "^10.0.1",
+    "@dicebear/styles": "^10.0.0",
     "@headlessui/vue": "^1.7.23",
     "@vueuse/core": "^14.3.0",
     "aplayer": "^1.10.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^0.1.53
         version: 0.1.53
       '@dicebear/core':
-        specifier: ^9.4.2
-        version: 9.4.2
-      '@dicebear/micah':
-        specifier: ^9.4.2
-        version: 9.4.2(@dicebear/core@9.4.2)
+        specifier: ^10.0.1
+        version: 10.0.1
+      '@dicebear/styles':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@headlessui/vue':
         specifier: ^1.7.23
         version: 1.7.23(vue@3.5.35(typescript@6.0.3))
@@ -418,15 +418,12 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.1.1
 
-  '@dicebear/core@9.4.2':
-    resolution: {integrity: sha512-MF0042+Z3s8PGZKZLySfhft28bUa3B1iq0e5NSjCvY8gfMi5aIH/iRJGRJa1N9Jz1BNkxYb4yvJ/N9KO8Z6Y+w==}
-    engines: {node: '>=18.0.0'}
+  '@dicebear/core@10.0.1':
+    resolution: {integrity: sha512-EUldm3THEc58Jz2/N8FsqKpgcJmYvjgwnf03EsIvuOVQ+wMad3r0AWwFB242879LMGU1tXqYpeGzcDblhWpTLQ==}
+    engines: {node: '>=22.0.0'}
 
-  '@dicebear/micah@9.4.2':
-    resolution: {integrity: sha512-e4D3W/OlChSsLo7Llwsy0J18vk0azJqF/uFoY+EKACCNHBc1HGNsqVvu2CTf+OWOA8wTyAK6UkjBN5p01r7D+g==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      '@dicebear/core': ^9.0.0
+  '@dicebear/styles@10.0.0':
+    resolution: {integrity: sha512-L98E+Am9ZG/nm9I05xthcBbuga/oxA2xkHUgkjcEO9hWzB1LU67pvU2BMrQphVKZ4rnzvLwibURe/41lHMC1/Q==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -3654,13 +3651,9 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.1
 
-  '@dicebear/core@9.4.2':
-    dependencies:
-      '@types/json-schema': 7.0.15
+  '@dicebear/core@10.0.1': {}
 
-  '@dicebear/micah@9.4.2(@dicebear/core@9.4.2)':
-    dependencies:
-      '@dicebear/core': 9.4.2
+  '@dicebear/styles@10.0.0': {}
 
   '@emnapi/core@1.10.0':
     dependencies:

--- a/web/src/components/common/BaseAvatar.vue
+++ b/web/src/components/common/BaseAvatar.vue
@@ -6,13 +6,18 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { createAvatar } from '@dicebear/core'
-import * as micah from '@dicebear/micah'
+import { Avatar, Style, type StyleOptions } from '@dicebear/core'
+import micah from '@dicebear/styles/micah.json'
 
+// DiceBear 10 distributes styles as JSON definitions. `new Style()` validates
+// the definition against its JSON Schema, so build it once at module scope and
+// reuse it for every avatar instead of paying that cost on each render.
+const micahStyle = new Style(micah)
+
+type MicahOptions = StyleOptions<typeof micah>
+type MicahOptionKey = keyof MicahOptions
 type AvatarOptionItem = string | number | boolean
 type AvatarOptionValue = AvatarOptionItem | AvatarOptionItem[] | null | undefined
-type MicahRuntimeOptions = NonNullable<Parameters<typeof micah.create>[0]['options']>
-type MicahOptionKey = keyof MicahRuntimeOptions
 type BaseAvatarOptions = Partial<Record<MicahOptionKey, AvatarOptionValue>>
 
 const avatarCache = new Map<string, string>()
@@ -41,7 +46,7 @@ const avatarSrc = computed(() => {
   const seed = props.seed.trim() || 'guest'
   const sizeNum = Number(props.size)
   const size = Number.isFinite(sizeNum) && sizeNum > 0 ? Math.round(sizeNum) : 128
-  const normalizedOptions: Partial<MicahRuntimeOptions> = {}
+  const normalizedOptions: Partial<MicahOptions> = {}
   const sortedOptionEntries = (
     Object.entries(props.options) as [MicahOptionKey, AvatarOptionValue][]
   ).sort(([a], [b]) => String(a).localeCompare(String(b)))
@@ -60,11 +65,11 @@ const avatarSrc = computed(() => {
   const cachedAvatar = avatarCache.get(cacheKey)
   if (cachedAvatar) return cachedAvatar
 
-  const generatedAvatar = createAvatar(micah, {
+  const generatedAvatar = new Avatar(micahStyle, {
     seed,
     size,
     ...normalizedOptions,
-  } as Record<string, unknown>).toDataUri()
+  } as MicahOptions).toDataUri()
 
   avatarCache.set(cacheKey, generatedAvatar)
   return generatedAvatar


### PR DESCRIPTION
Properly completes Dependabot #274, which bumped `@dicebear/core` to v10 but left `@dicebear/micah` at v9 — that combination breaks the build, because DiceBear 10 removed the per-style npm packages (`@dicebear/micah` has no v10) and now distributes styles as JSON via `@dicebear/styles`, while also dropping the `createAvatar()` API in favor of the `Style`/`Avatar` classes.

## Changes
- `@dicebear/micah` → `@dicebear/styles` (`^10.0.0`), `@dicebear/core` → `^10.0.1`
- `BaseAvatar.vue` rewritten to the v10 API: `new Avatar(style, opts).toDataUri()`
- Performance: the validated `Style` is built **once at module scope** (`new Style()` runs JSON-Schema validation) and reused across renders, instead of re-passing the style collection on every call
- Typed `options` prop preserved, now derived from `StyleOptions<typeof micah>`

## Why it's also lighter
`@dicebear/core@10` has **zero** runtime deps and `@dicebear/styles` is pure JSON — in v9 `@dicebear/micah` depended on core. Net dependency weight drops.

## Verification
- `pnpm build` (vue-tsc type-check + vite build) ✅
- `vitest run` — 34/34 ✅
- `eslint` on changed file ✅
- `i18n:check` (key / unused / hardcoded / pseudo-smoke) ✅
- Runtime smoke: `new Avatar(new Style(micah), { seed, size }).toDataUri()` returns a valid `data:image/svg+xml` URI ✅

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)