### PR TITLE
feat(auth): migrate local password to user_local_auth with bcrypt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/wneessen/go-mail v0.8.0
+	golang.org/x/crypto v0.53.0
 	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.56.0
 	golang.org/x/oauth2 v0.36.0
@@ -134,7 +135,6 @@ require (
 	go.mongodb.org/mongo-driver/v2 v2.6.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/arch v0.27.0 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/google/go-tpm v0.9.8/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u
 github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba h1:qJEJcuLzH5KDR0gKc0zcktin6KSAwL7+jWKBYceddTc=
 github.com/google/go-tpm-tools v0.3.13-0.20230620182252-4639ecce2aba/go.mod h1:EFYHy8/1y2KfgTAsx7Luu7NGhoxtuVHnNo8jE7FikKc=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.7.0 h1:JxUKI6+CVBgCO2WToKy/nQk0sS+amI9z9EjVmdaocj4=
@@ -309,6 +311,8 @@ golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
 golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
+golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
+golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -131,6 +131,9 @@ func InitDatabase() {
 			dbMigration.NewLegacyInboxesDropMigrator(),
 			dbMigration.NewAgentProtocolCollapseMigrator(),
 			dbMigration.NewAgentSettingProtocolRenameMigrator(),
+			// 本地密码迁入 user_local_auth：回填必须先于删列。
+			dbMigration.NewUserLocalAuthBackfillMigrator(),
+			dbMigration.NewUsersPasswordDropMigrator(),
 		),
 	)
 }

--- a/internal/database/migration/user_local_auth_backfill_migrator.go
+++ b/internal/database/migration/user_local_auth_backfill_migrator.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
+package migration
+
+import (
+	"fmt"
+
+	commonModel "github.com/lin-snow/ech0/internal/model/common"
+	userModel "github.com/lin-snow/ech0/internal/model/user"
+	"gorm.io/gorm"
+)
+
+// userLocalAuthBackfillMigrator 把存量的本地密码从 users.password（历史裸 MD5）
+// 回填进独立的 user_local_auth 表，算法标记为 md5，等待下次登录时惰性升级为 bcrypt。
+//
+// 幂等双保险：
+//   - 框架级：CanRerun()=false + 标记键，成功后写 KeyValue，重启即跳过；
+//   - 语句级：user_local_auth.user_id 是主键，INSERT OR IGNORE 不会覆盖用户已改过的哈希。
+//
+// 新库（users 无 password 列）直接跳过——没有任何存量可回填。
+type userLocalAuthBackfillMigrator struct{}
+
+func NewUserLocalAuthBackfillMigrator() Migrator {
+	return &userLocalAuthBackfillMigrator{}
+}
+
+func (m *userLocalAuthBackfillMigrator) Name() string {
+	return "user_local_auth_backfill_migrator"
+}
+
+func (m *userLocalAuthBackfillMigrator) Key() string {
+	return commonModel.UserLocalAuthBackfilledKey
+}
+
+func (m *userLocalAuthBackfillMigrator) CanRerun() bool {
+	return false
+}
+
+func (m *userLocalAuthBackfillMigrator) Migrate(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	// 新库或已删列：无 users.password 列，无存量可回填。
+	if !db.Migrator().HasColumn(&userModel.User{}, "password") {
+		return nil
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		// user_id 主键 → INSERT OR IGNORE 保证幂等；仅回填有非空密码、且尚无本地认证行的用户。
+		return tx.Exec(`
+			INSERT OR IGNORE INTO user_local_auth (user_id, password_hash, password_algo, updated_at)
+			SELECT id, password, 'md5', CAST(strftime('%s','now') AS INTEGER)
+			FROM users
+			WHERE password IS NOT NULL AND password <> ''
+		`).Error
+	})
+}

--- a/internal/database/migration/user_local_auth_backfill_migrator_test.go
+++ b/internal/database/migration/user_local_auth_backfill_migrator_test.go
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
+package migration_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lin-snow/ech0/internal/database"
+	dbMigration "github.com/lin-snow/ech0/internal/database/migration"
+	commonModel "github.com/lin-snow/ech0/internal/model/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// newLocalAuthTestDB 打开内存 sqlite 并跑 AutoMigrate。注意：新 User 结构体已无 password 字段，
+// 故此时 users 表**没有** password 列 —— 模拟旧库需另行 addLegacyPasswordColumn。
+func newLocalAuthTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	database.SetDB(db)
+	require.NoError(t, database.MigrateDB())
+	return db
+}
+
+func addLegacyPasswordColumn(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec(`ALTER TABLE users ADD COLUMN password TEXT`).Error)
+}
+
+func seedLegacyUser(t *testing.T, db *gorm.DB, id, username, md5pw string) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		`INSERT INTO users (id, username, password, is_admin, is_owner, locale) VALUES (?,?,?,?,?,?)`,
+		id, username, md5pw, false, false, "zh-CN",
+	).Error)
+}
+
+type localAuthRow struct {
+	UserID       string
+	PasswordHash string
+	PasswordAlgo string
+}
+
+func readLocalAuth(t *testing.T, db *gorm.DB, userID string) (localAuthRow, bool) {
+	t.Helper()
+	var row localAuthRow
+	err := db.Raw(
+		`SELECT user_id, password_hash, password_algo FROM user_local_auth WHERE user_id = ?`, userID,
+	).Scan(&row).Error
+	require.NoError(t, err)
+	return row, row.UserID != ""
+}
+
+func countLocalAuth(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Table("user_local_auth").Count(&n).Error)
+	return n
+}
+
+func TestUserLocalAuthBackfillMigrator_BackfillsLegacyPassword(t *testing.T) {
+	db := newLocalAuthTestDB(t)
+	addLegacyPasswordColumn(t, db)
+	seedLegacyUser(t, db, "u1", "alice", "5f4dcc3b5aa765d61d8327deb882cf99")
+
+	dbMigration.Migrate(
+		db,
+		dbMigration.WithStopOnError(),
+		dbMigration.WithMigrators(dbMigration.NewUserLocalAuthBackfillMigrator()),
+	)
+
+	row, ok := readLocalAuth(t, db, "u1")
+	require.True(t, ok, "expected user_local_auth row for u1")
+	assert.Equal(t, "5f4dcc3b5aa765d61d8327deb882cf99", row.PasswordHash)
+	assert.Equal(t, "md5", row.PasswordAlgo)
+
+	// 幂等标记应写入。
+	var marker commonModel.KeyValue
+	require.NoError(t, db.Where("key = ?", commonModel.UserLocalAuthBackfilledKey).First(&marker).Error)
+}
+
+func TestUserLocalAuthBackfillMigrator_Idempotent(t *testing.T) {
+	db := newLocalAuthTestDB(t)
+	addLegacyPasswordColumn(t, db)
+	seedLegacyUser(t, db, "u1", "alice", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	m := dbMigration.NewUserLocalAuthBackfillMigrator()
+	require.NoError(t, m.Migrate(db))
+
+	// 模拟该用户登录后已惰性升级为 bcrypt。
+	require.NoError(t, db.Exec(
+		`UPDATE user_local_auth SET password_hash = ?, password_algo = ? WHERE user_id = ?`,
+		"$2a$10$bcrypthashplaceholdervalueaaaaaaaaaaaaaaaaaaaaaaaaaaa", "bcrypt", "u1",
+	).Error)
+
+	// 二次回填（INSERT OR IGNORE）不得覆盖已升级的 bcrypt 哈希，也不得产生重复行。
+	require.NoError(t, m.Migrate(db))
+
+	assert.Equal(t, int64(1), countLocalAuth(t, db))
+	row, ok := readLocalAuth(t, db, "u1")
+	require.True(t, ok)
+	assert.Equal(t, "bcrypt", row.PasswordAlgo, "已升级的哈希不应被回填覆盖")
+}
+
+func TestUserLocalAuthBackfillMigrator_NoOpWhenNoPasswordColumn(t *testing.T) {
+	db := newLocalAuthTestDB(t) // 新库：users 没有 password 列
+	require.NoError(t, db.Exec(
+		`INSERT INTO users (id, username, is_admin, is_owner, locale) VALUES ('u1','alice',0,0,'zh-CN')`,
+	).Error)
+
+	require.NoError(t, dbMigration.NewUserLocalAuthBackfillMigrator().Migrate(db))
+	assert.Equal(t, int64(0), countLocalAuth(t, db), "无 password 列时不应回填")
+}
+
+func TestUsersPasswordDropMigrator_DropsColumn(t *testing.T) {
+	db := newLocalAuthTestDB(t)
+	addLegacyPasswordColumn(t, db)
+	assert.True(t, db.Migrator().HasColumn("users", "password"))
+
+	dbMigration.Migrate(
+		db,
+		dbMigration.WithStopOnError(),
+		dbMigration.WithMigrators(dbMigration.NewUsersPasswordDropMigrator()),
+	)
+
+	assert.False(t, db.Migrator().HasColumn("users", "password"), "password 列应被删除")
+
+	// 新库无该列时应为幂等 no-op。
+	require.NoError(t, dbMigration.NewUsersPasswordDropMigrator().Migrate(db))
+}

--- a/internal/database/migration/users_password_drop_migrator.go
+++ b/internal/database/migration/users_password_drop_migrator.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
+package migration
+
+import (
+	"fmt"
+
+	commonModel "github.com/lin-snow/ech0/internal/model/common"
+	userModel "github.com/lin-snow/ech0/internal/model/user"
+	"gorm.io/gorm"
+)
+
+// usersPasswordDropMigrator 删除 users 表遗留的 password 列。
+//
+// 本地密码已迁入 user_local_auth（见 userLocalAuthBackfillMigrator，务必排在其之后），
+// 保留旧列意味着历史裸 MD5 仍残留在 users 表里 —— 删列才是安全升级的收口。
+//
+// SQLite 3.35+ 支持 ALTER TABLE ... DROP COLUMN；password 是无索引的普通列，可直接删。
+// HasColumn 守卫使之天然幂等：列不存在（新库或已删）即跳过。
+type usersPasswordDropMigrator struct{}
+
+func NewUsersPasswordDropMigrator() Migrator {
+	return &usersPasswordDropMigrator{}
+}
+
+func (m *usersPasswordDropMigrator) Name() string {
+	return "users_password_drop_migrator"
+}
+
+func (m *usersPasswordDropMigrator) Key() string {
+	return commonModel.UsersPasswordColumnDroppedKey
+}
+
+func (m *usersPasswordDropMigrator) CanRerun() bool {
+	return false
+}
+
+func (m *usersPasswordDropMigrator) Migrate(db *gorm.DB) error {
+	if db == nil {
+		return fmt.Errorf("database not initialized")
+	}
+	if !db.Migrator().HasColumn(&userModel.User{}, "password") {
+		return nil
+	}
+	return db.Exec(`ALTER TABLE users DROP COLUMN password`).Error
+}

--- a/internal/handler/auth/auth_handler_test.go
+++ b/internal/handler/auth/auth_handler_test.go
@@ -132,7 +132,6 @@ func (f *fakeUserService) DeleteUser(context.Context, string) error {
 var testUser = userModel.User{
 	ID:       "test-user-id-001",
 	Username: "testuser",
-	Password: "hashed",
 }
 
 func init() {

--- a/internal/handler/user/user.go
+++ b/internal/handler/user/user.go
@@ -84,7 +84,6 @@ func (userHandler *UserHandler) DeleteUser(ctx context.Context, in *DeleteUserIn
 func (userHandler *UserHandler) GetUserInfo(ctx context.Context, _ *GetUserInfoInput) (UserOutput, error) {
 	userid := viewer.MustFromContext(ctx).UserID()
 	user, err := userHandler.userService.GetUserByID(userid)
-	user.Password = ""
 	if err != nil {
 		return UserOutput{}, err
 	}

--- a/internal/handler/user/user_test.go
+++ b/internal/handler/user/user_test.go
@@ -168,12 +168,12 @@ func TestUserHandler_DeleteUser(t *testing.T) {
 }
 
 func TestUserHandler_GetUserInfo(t *testing.T) {
-	t.Run("success scrubs password and resolves viewer id", func(t *testing.T) {
+	t.Run("success resolves viewer id", func(t *testing.T) {
 		svc := usermock.NewMockService(t)
-		// 服务层返回带密码哈希的用户；handler 必须把 Password 脱敏为空。
+		// 用户实体已不含密码字段（密码存于 user_local_auth），handler 直接返回用户信息。
 		svc.EXPECT().
 			GetUserByID("viewer-1").
-			Return(userModel.User{ID: "viewer-1", Username: "alice", Password: "secret-hash"}, nil).
+			Return(userModel.User{ID: "viewer-1", Username: "alice"}, nil).
 			Once()
 
 		h := userHandler.NewUserHandler(svc)
@@ -182,7 +182,6 @@ func TestUserHandler_GetUserInfo(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, commonModel.GET_USER_INFO_SUCCESS, out.Message)
 		assert.Equal(t, "alice", out.Data.Username)
-		assert.Empty(t, out.Data.Password, "password 必须脱敏")
 	})
 
 	t.Run("error", func(t *testing.T) {

--- a/internal/model/common/common.go
+++ b/internal/model/common/common.go
@@ -109,6 +109,10 @@ const (
 	AgentProtocolCollapsedKey = "agent_provider_collapsed_v1"
 	// AgentSettingProtocolRenamedKey 是把 agent_setting JSON 里 "provider" 字段重命名为 "protocol" 的幂等标记键
 	AgentSettingProtocolRenamedKey = "agent_setting_protocol_renamed_v1"
+	// UserLocalAuthBackfilledKey 是把存量 users.password 回填进 user_local_auth 表的幂等标记键
+	UserLocalAuthBackfilledKey = "user_local_auth_backfilled_v1"
+	// UsersPasswordColumnDroppedKey 是回填后删除 users.password 遗留列的幂等标记键
+	UsersPasswordColumnDroppedKey = "users_password_column_dropped_v1"
 	// ChatSessionKeyPrefix 是 Chat 持久化会话的键前缀（每个 userID 一条，键为前缀 + userID）
 	ChatSessionKeyPrefix = "chat_session:"
 )

--- a/internal/model/common/error.go
+++ b/internal/model/common/error.go
@@ -76,6 +76,7 @@ const (
 const (
 	USERNAME_OR_PASSWORD_NOT_BE_EMPTY = "用户名或密码不能为空"
 	PASSWORD_INCORRECT                = "密码错误"
+	PASSWORD_TOO_LONG                 = "密码过长，最多 72 字节"
 	USER_NOTFOUND                     = "用户不存在"
 	USER_COUNT_EXCEED_LIMIT           = "用户数量超过限制"
 	USERNAME_HAS_EXISTS               = "用户名已存在"

--- a/internal/model/user/user.go
+++ b/internal/model/user/user.go
@@ -17,7 +17,6 @@ type User struct {
 	ID       string `gorm:"type:char(36);primaryKey" json:"id"`
 	Username string `gorm:"size:255;not null;unique" json:"username"`
 	Email    string `gorm:"size:255;index"            json:"email"`
-	Password string `gorm:"size:255;not null"        json:"-"`
 	IsAdmin  bool   `gorm:"bool"                     json:"is_admin"`
 	IsOwner  bool   `gorm:"bool"                     json:"is_owner"`
 	Avatar   string `gorm:"size:255"                 json:"avatar"`

--- a/internal/repository/auth/auth.go
+++ b/internal/repository/auth/auth.go
@@ -95,6 +95,27 @@ func (authRepository *AuthRepository) GetUserByUsername(ctx context.Context, use
 	return user, nil
 }
 
+// GetLocalAuthByUserID 读取用户的本地密码认证行（user_local_auth）。
+// 无行（gorm.ErrRecordNotFound）表示该账号未设本地密码，调用方应按凭证错误处理。
+func (authRepository *AuthRepository) GetLocalAuthByUserID(ctx context.Context, userID string) (model.UserLocalAuth, error) {
+	var localAuth model.UserLocalAuth
+	if err := authRepository.getDB(ctx).Where("user_id = ?", userID).First(&localAuth).Error; err != nil {
+		return model.UserLocalAuth{}, err
+	}
+	return localAuth, nil
+}
+
+// UpdateLocalAuthPassword 更新用户本地密码认证行的哈希与算法，供登录时惰性升级（md5 → bcrypt）使用。
+func (authRepository *AuthRepository) UpdateLocalAuthPassword(ctx context.Context, userID, passwordHash, passwordAlgo string) error {
+	return authRepository.getDB(ctx).
+		Model(&model.UserLocalAuth{}).
+		Where("user_id = ?", userID).
+		Updates(map[string]any{
+			"password_hash": passwordHash,
+			"password_algo": passwordAlgo,
+		}).Error
+}
+
 func (authRepository *AuthRepository) getUserByID(ctx context.Context, id string) (model.User, error) {
 	var user model.User
 	if err := authRepository.getDB(ctx).Where("id = ?", id).First(&user).Error; err != nil {

--- a/internal/repository/auth/auth_local_auth_repo_test.go
+++ b/internal/repository/auth/auth_local_auth_repo_test.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	userModel "github.com/lin-snow/ech0/internal/model/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestAuthRepository_GetLocalAuthByUserID(t *testing.T) {
+	repo, db, _ := newAuthRepo(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&userModel.UserLocalAuth{
+		UserID: "u1", PasswordHash: "hash", PasswordAlgo: "md5",
+	}).Error)
+
+	got, err := repo.GetLocalAuthByUserID(ctx, "u1")
+	require.NoError(t, err)
+	assert.Equal(t, "hash", got.PasswordHash)
+	assert.Equal(t, "md5", got.PasswordAlgo)
+
+	// 无行时返回 ErrRecordNotFound，供登录侧统一按凭证错误处理。
+	_, err = repo.GetLocalAuthByUserID(ctx, "ghost")
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}
+
+func TestAuthRepository_UpdateLocalAuthPassword(t *testing.T) {
+	repo, db, _ := newAuthRepo(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&userModel.UserLocalAuth{
+		UserID: "u1", PasswordHash: "old-md5", PasswordAlgo: "md5",
+	}).Error)
+
+	require.NoError(t, repo.UpdateLocalAuthPassword(ctx, "u1", "new-bcrypt", "bcrypt"))
+
+	var row userModel.UserLocalAuth
+	require.NoError(t, db.Where("user_id = ?", "u1").First(&row).Error)
+	assert.Equal(t, "new-bcrypt", row.PasswordHash)
+	assert.Equal(t, "bcrypt", row.PasswordAlgo)
+}

--- a/internal/repository/user/user.go
+++ b/internal/repository/user/user.go
@@ -11,6 +11,7 @@ import (
 	model "github.com/lin-snow/ech0/internal/model/user"
 	"github.com/lin-snow/ech0/internal/transaction"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type UserRepository struct {
@@ -82,6 +83,15 @@ func (userRepository *UserRepository) CreateUser(ctx context.Context, user *mode
 		userRepository.cache.Set(GetOwnerKey(), *user, 1)
 	}
 	return nil
+}
+
+// UpsertLocalAuth 写入或更新用户的本地密码认证行（user_local_auth），user_id 冲突时覆盖
+// 哈希/算法/更新时间。用于注册、初始化 owner 和管理员改密。
+func (userRepository *UserRepository) UpsertLocalAuth(ctx context.Context, localAuth *model.UserLocalAuth) error {
+	return userRepository.getDB(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"password_hash", "password_algo", "updated_at"}),
+	}).Create(localAuth).Error
 }
 
 func (userRepository *UserRepository) GetUserByID(ctx context.Context, id string) (model.User, error) {
@@ -203,6 +213,13 @@ func (userRepository *UserRepository) DeleteUser(ctx context.Context, id string)
 
 	err = userRepository.getDB(ctx).Where("id = ?", id).Delete(&model.User{}).Error
 	if err != nil {
+		return err
+	}
+
+	// 一并清理本地密码认证行，避免遗留孤儿。
+	if err := userRepository.getDB(ctx).
+		Where("user_id = ?", id).
+		Delete(&model.UserLocalAuth{}).Error; err != nil {
 		return err
 	}
 

--- a/internal/repository/user/user_local_auth_repo_test.go
+++ b/internal/repository/user/user_local_auth_repo_test.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2025-2026 lin-snow
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	userModel "github.com/lin-snow/ech0/internal/model/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserRepository_UpsertLocalAuth(t *testing.T) {
+	repo, db, _ := newUserRepo(t)
+	ctx := context.Background()
+
+	// 初次插入。
+	require.NoError(t, repo.UpsertLocalAuth(ctx, &userModel.UserLocalAuth{
+		UserID: "u1", PasswordHash: "hash-md5", PasswordAlgo: "md5",
+	}))
+	var row userModel.UserLocalAuth
+	require.NoError(t, db.Where("user_id = ?", "u1").First(&row).Error)
+	assert.Equal(t, "hash-md5", row.PasswordHash)
+	assert.Equal(t, "md5", row.PasswordAlgo)
+	assert.NotZero(t, row.UpdatedAt, "autoUpdateTime 应被填充")
+
+	// user_id 主键冲突 → 覆盖 hash/algo，而非插入新行。
+	require.NoError(t, repo.UpsertLocalAuth(ctx, &userModel.UserLocalAuth{
+		UserID: "u1", PasswordHash: "hash-bcrypt", PasswordAlgo: "bcrypt",
+	}))
+	var count int64
+	require.NoError(t, db.Model(&userModel.UserLocalAuth{}).Where("user_id = ?", "u1").Count(&count).Error)
+	assert.Equal(t, int64(1), count, "冲突应更新而非新增")
+	require.NoError(t, db.Where("user_id = ?", "u1").First(&row).Error)
+	assert.Equal(t, "hash-bcrypt", row.PasswordHash)
+	assert.Equal(t, "bcrypt", row.PasswordAlgo)
+}
+
+func TestUserRepository_DeleteUser_RemovesLocalAuth(t *testing.T) {
+	repo, db, _ := newUserRepo(t)
+	ctx := context.Background()
+
+	seedUser(t, db, userModel.User{ID: "u1", Username: "alice"})
+	require.NoError(t, repo.UpsertLocalAuth(ctx, &userModel.UserLocalAuth{
+		UserID: "u1", PasswordHash: "h", PasswordAlgo: "bcrypt",
+	}))
+
+	require.NoError(t, repo.DeleteUser(ctx, "u1"))
+
+	var count int64
+	require.NoError(t, db.Model(&userModel.UserLocalAuth{}).Where("user_id = ?", "u1").Count(&count).Error)
+	assert.Equal(t, int64(0), count, "删除用户应一并清理其本地认证行")
+}

--- a/internal/repository/user/user_repo_cache_test.go
+++ b/internal/repository/user/user_repo_cache_test.go
@@ -45,7 +45,7 @@ func seedUser(t *testing.T, db *gorm.DB, u userModel.User) userModel.User {
 func TestUserRepository_UpdateUser_CacheCoordination(t *testing.T) {
 	t.Run("rename deletes the old username key and sets the new one", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		existing := seedUser(t, db, userModel.User{ID: "u1", Username: "old", Password: "p"})
+		existing := seedUser(t, db, userModel.User{ID: "u1", Username: "old"})
 		c.Set(GetUsernameKey("old"), existing, 1)
 
 		updated := existing
@@ -70,7 +70,7 @@ func TestUserRepository_UpdateUser_CacheCoordination(t *testing.T) {
 
 	t.Run("admin downgrade deletes the admin key", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		existing := seedUser(t, db, userModel.User{ID: "u1", Username: "a", Password: "p", IsAdmin: true})
+		existing := seedUser(t, db, userModel.User{ID: "u1", Username: "a", IsAdmin: true})
 		c.Set(GetAdminKey("u1"), existing, 1)
 
 		updated := existing
@@ -87,7 +87,7 @@ func TestUserRepository_UpdateUser_CacheCoordination(t *testing.T) {
 
 	t.Run("owner downgrade deletes the owner key", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		existing := seedUser(t, db, userModel.User{ID: "u1", Username: "o", Password: "p", IsAdmin: true, IsOwner: true})
+		existing := seedUser(t, db, userModel.User{ID: "u1", Username: "o", IsAdmin: true, IsOwner: true})
 		c.Set(GetOwnerKey(), existing, 1)
 
 		updated := existing
@@ -100,7 +100,7 @@ func TestUserRepository_UpdateUser_CacheCoordination(t *testing.T) {
 
 	t.Run("promotion to admin and owner sets id/username/admin/owner keys", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		existing := seedUser(t, db, userModel.User{ID: "u1", Username: "x", Password: "p"})
+		existing := seedUser(t, db, userModel.User{ID: "u1", Username: "x"})
 
 		updated := existing
 		updated.IsAdmin = true
@@ -127,7 +127,7 @@ func TestUserRepository_UpdateUser_CacheCoordination(t *testing.T) {
 	t.Run("updating a missing user errors and writes no cache", func(t *testing.T) {
 		repo, _, c := newUserRepo(t)
 
-		missing := userModel.User{ID: "ghost", Username: "ghost", Password: "p"}
+		missing := userModel.User{ID: "ghost", Username: "ghost"}
 		err := repo.UpdateUser(context.Background(), &missing)
 		require.ErrorIs(t, err, gorm.ErrRecordNotFound)
 
@@ -140,7 +140,7 @@ func TestUserRepository_CreateUser_KeyFanout(t *testing.T) {
 	t.Run("non-owner sets only id and username keys", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
 
-		user := userModel.User{ID: "u1", Username: "alice", Password: "p", IsAdmin: true}
+		user := userModel.User{ID: "u1", Username: "alice", IsAdmin: true}
 		require.NoError(t, repo.CreateUser(context.Background(), &user))
 
 		gotID, ok := cacheGetUser(t, c, GetUserIDKey("u1"))
@@ -164,7 +164,7 @@ func TestUserRepository_CreateUser_KeyFanout(t *testing.T) {
 	t.Run("owner also sets the owner key", func(t *testing.T) {
 		repo, _, c := newUserRepo(t)
 
-		user := userModel.User{ID: "u1", Username: "boss", Password: "p", IsAdmin: true, IsOwner: true}
+		user := userModel.User{ID: "u1", Username: "boss", IsAdmin: true, IsOwner: true}
 		require.NoError(t, repo.CreateUser(context.Background(), &user))
 
 		gotOwner, ok := cacheGetUser(t, c, GetOwnerKey())
@@ -181,7 +181,7 @@ func TestUserRepository_CreateUser_KeyFanout(t *testing.T) {
 func TestUserRepository_DeleteUser_KeyFanout(t *testing.T) {
 	t.Run("admin owner deletes id/username/admin/owner keys", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		u := seedUser(t, db, userModel.User{ID: "u1", Username: "boss", Password: "p", IsAdmin: true, IsOwner: true})
+		u := seedUser(t, db, userModel.User{ID: "u1", Username: "boss", IsAdmin: true, IsOwner: true})
 		c.Set(GetUserIDKey("u1"), u, 1)
 		c.Set(GetUsernameKey("boss"), u, 1)
 		c.Set(GetAdminKey("u1"), u, 1)
@@ -201,7 +201,7 @@ func TestUserRepository_DeleteUser_KeyFanout(t *testing.T) {
 
 	t.Run("regular user deletes only id/username keys and leaves admin/owner keys", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		u := seedUser(t, db, userModel.User{ID: "u1", Username: "bob", Password: "p"})
+		u := seedUser(t, db, userModel.User{ID: "u1", Username: "bob"})
 		c.Set(GetUserIDKey("u1"), u, 1)
 		c.Set(GetUsernameKey("bob"), u, 1)
 		// 这两个键不属于该用户的清理范围，必须保留。
@@ -267,8 +267,8 @@ func TestUserRepository_GetAllUsers(t *testing.T) {
 
 	t.Run("returns every inserted user", func(t *testing.T) {
 		repo, db, _ := newUserRepo(t)
-		seedUser(t, db, userModel.User{ID: "u1", Username: "a", Password: "p"})
-		seedUser(t, db, userModel.User{ID: "u2", Username: "b", Password: "p"})
+		seedUser(t, db, userModel.User{ID: "u1", Username: "a"})
+		seedUser(t, db, userModel.User{ID: "u2", Username: "b"})
 
 		got, err := repo.GetAllUsers(context.Background())
 		require.NoError(t, err)
@@ -298,7 +298,7 @@ func TestUserRepository_GetUserByID_ReadThrough(t *testing.T) {
 
 	t.Run("cache miss reads db and backfills", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		want := seedUser(t, db, userModel.User{ID: "u1", Username: "dbuser", Password: "p"})
+		want := seedUser(t, db, userModel.User{ID: "u1", Username: "dbuser"})
 
 		got, err := repo.GetUserByID(context.Background(), "u1")
 		require.NoError(t, err)
@@ -311,7 +311,7 @@ func TestUserRepository_GetUserByID_ReadThrough(t *testing.T) {
 
 	t.Run("transaction context bypasses cache", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		want := seedUser(t, db, userModel.User{ID: "u1", Username: "dbuser", Password: "p"})
+		want := seedUser(t, db, userModel.User{ID: "u1", Username: "dbuser"})
 		stale := userModel.User{ID: "u1", Username: "stale"}
 		c.Set(GetUserIDKey("u1"), stale, 1)
 
@@ -345,7 +345,7 @@ func TestUserRepository_GetUserByUsername_ReadThrough(t *testing.T) {
 
 	t.Run("cache miss reads db and backfills", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		want := seedUser(t, db, userModel.User{ID: "u1", Username: "alice", Password: "p"})
+		want := seedUser(t, db, userModel.User{ID: "u1", Username: "alice"})
 
 		got, err := repo.GetUserByUsername(context.Background(), "alice")
 		require.NoError(t, err)
@@ -358,7 +358,7 @@ func TestUserRepository_GetUserByUsername_ReadThrough(t *testing.T) {
 
 	t.Run("transaction context bypasses cache", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		want := seedUser(t, db, userModel.User{ID: "u1", Username: "alice", Password: "p"})
+		want := seedUser(t, db, userModel.User{ID: "u1", Username: "alice"})
 		stale := userModel.User{ID: "u9", Username: "alice"}
 		c.Set(GetUsernameKey("alice"), stale, 1)
 
@@ -393,8 +393,8 @@ func TestUserRepository_GetOwner_ReadThrough(t *testing.T) {
 	t.Run("cache miss reads db and backfills", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
 		// 写一个非站长用户，确保查询条件 is_owner=true 命中的是正确那条。
-		seedUser(t, db, userModel.User{ID: "u2", Username: "plain", Password: "p"})
-		want := seedUser(t, db, userModel.User{ID: "u1", Username: "owner", Password: "p", IsAdmin: true, IsOwner: true})
+		seedUser(t, db, userModel.User{ID: "u2", Username: "plain"})
+		want := seedUser(t, db, userModel.User{ID: "u1", Username: "owner", IsAdmin: true, IsOwner: true})
 
 		got, err := repo.GetOwner(context.Background())
 		require.NoError(t, err)
@@ -407,7 +407,7 @@ func TestUserRepository_GetOwner_ReadThrough(t *testing.T) {
 
 	t.Run("transaction context bypasses cache", func(t *testing.T) {
 		repo, db, c := newUserRepo(t)
-		want := seedUser(t, db, userModel.User{ID: "u1", Username: "owner", Password: "p", IsAdmin: true, IsOwner: true})
+		want := seedUser(t, db, userModel.User{ID: "u1", Username: "owner", IsAdmin: true, IsOwner: true})
 		stale := userModel.User{ID: "u9", Username: "stale-owner", IsOwner: true}
 		c.Set(GetOwnerKey(), stale, 1)
 

--- a/internal/service/auth/auth.go
+++ b/internal/service/auth/auth.go
@@ -97,14 +97,36 @@ func (authService *AuthService) Login(loginDto *authModel.LoginDto) (*authModel.
 		return nil, errors.New(commonModel.USERNAME_OR_PASSWORD_NOT_BE_EMPTY)
 	}
 
-	loginDto.Password = cryptoUtil.MD5Encrypt(loginDto.Password)
-	user, err := authService.repository.GetUserByUsername(context.Background(), loginDto.Username)
+	ctx := context.Background()
+	user, err := authService.repository.GetUserByUsername(ctx, loginDto.Username)
 	if err != nil {
 		return nil, errors.New(commonModel.USER_NOTFOUND)
 	}
-	if user.Password != loginDto.Password {
+
+	localAuth, err := authService.repository.GetLocalAuthByUserID(ctx, user.ID)
+	if err != nil {
+		// 无本地密码认证行（纯外部身份账号或数据缺失）→ 统一按凭证错误处理，不泄露具体原因
 		return nil, errors.New(commonModel.PASSWORD_INCORRECT)
 	}
+	if !cryptoUtil.CheckPassword(localAuth.PasswordAlgo, localAuth.PasswordHash, loginDto.Password) {
+		return nil, errors.New(commonModel.PASSWORD_INCORRECT)
+	}
+
+	// 惰性升级：存量非 bcrypt 口令校验通过后，就地换算为 bcrypt 落库。
+	// best-effort —— 升级写失败只告警，绝不阻断这次已认证成功的登录。
+	if localAuth.PasswordAlgo != cryptoUtil.AlgoBcrypt {
+		if newHash, hashErr := cryptoUtil.HashPassword(loginDto.Password); hashErr == nil {
+			if upErr := authService.repository.UpdateLocalAuthPassword(ctx, user.ID, newHash, cryptoUtil.AlgoBcrypt); upErr != nil {
+				logUtil.GetLogger().Warn(
+					"lazy upgrade password hash failed",
+					slog.String("module", "auth"),
+					slog.String("user_id", user.ID),
+					logUtil.Err(upErr),
+				)
+			}
+		}
+	}
+
 	return authService.issueUserToken(user)
 }
 

--- a/internal/service/auth/auth.go
+++ b/internal/service/auth/auth.go
@@ -35,6 +35,7 @@ import (
 	logUtil "github.com/lin-snow/ech0/pkg/log"
 	"github.com/lin-snow/ech0/pkg/viewer"
 	"golang.org/x/oauth2"
+	"gorm.io/gorm"
 )
 
 // oidcHTTPClient is the shared client for outbound OIDC/OAuth2 requests. It
@@ -105,7 +106,16 @@ func (authService *AuthService) Login(loginDto *authModel.LoginDto) (*authModel.
 
 	localAuth, err := authService.repository.GetLocalAuthByUserID(ctx, user.ID)
 	if err != nil {
-		// 无本地密码认证行（纯外部身份账号或数据缺失）→ 统一按凭证错误处理，不泄露具体原因
+		// 无本地密码认证行（纯外部身份账号）→ 统一按凭证错误处理，不泄露"无本地密码"。
+		// 但真实 DB 故障要留痕：否则瞬时故障会被误显示为"密码错误"，且无从排障。
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			logUtil.GetLogger().Warn(
+				"load local auth failed",
+				slog.String("module", "auth"),
+				slog.String("user_id", user.ID),
+				logUtil.Err(err),
+			)
+		}
 		return nil, errors.New(commonModel.PASSWORD_INCORRECT)
 	}
 	if !cryptoUtil.CheckPassword(localAuth.PasswordAlgo, localAuth.PasswordHash, loginDto.Password) {

--- a/internal/service/auth/login_test.go
+++ b/internal/service/auth/login_test.go
@@ -41,7 +41,10 @@ func TestLogin(t *testing.T) {
 
 	const username = "alice"
 	const plainPassword = "s3cr3t"
-	hashed := cryptoUtil.MD5Encrypt(plainPassword)
+	const userID = "u-1"
+	md5Hash := cryptoUtil.MD5Encrypt(plainPassword)
+	bcryptHash, err := cryptoUtil.HashPassword(plainPassword)
+	require.NoError(t, err)
 
 	cases := []struct {
 		name      string
@@ -73,12 +76,35 @@ func TestLogin(t *testing.T) {
 			wantErr: commonModel.USER_NOTFOUND,
 		},
 		{
+			name: "missing local auth row maps to PASSWORD_INCORRECT",
+			dto:  authModel.LoginDto{Username: username, Password: plainPassword},
+			setupRepo: func(repo *authmock.MockRepository) {
+				repo.EXPECT().
+					GetUserByUsername(mock.Anything, username).
+					Return(userModel.User{ID: userID, Username: username}, nil).
+					Once()
+				repo.EXPECT().
+					GetLocalAuthByUserID(mock.Anything, userID).
+					Return(userModel.UserLocalAuth{}, errors.New("record not found")).
+					Once()
+			},
+			wantErr: commonModel.PASSWORD_INCORRECT,
+		},
+		{
 			name: "wrong password maps to PASSWORD_INCORRECT",
 			dto:  authModel.LoginDto{Username: username, Password: plainPassword},
 			setupRepo: func(repo *authmock.MockRepository) {
 				repo.EXPECT().
 					GetUserByUsername(mock.Anything, username).
-					Return(userModel.User{ID: "u-1", Username: username, Password: "different-hash"}, nil).
+					Return(userModel.User{ID: userID, Username: username}, nil).
+					Once()
+				repo.EXPECT().
+					GetLocalAuthByUserID(mock.Anything, userID).
+					Return(userModel.UserLocalAuth{
+						UserID:       userID,
+						PasswordHash: cryptoUtil.MD5Encrypt("another-password"),
+						PasswordAlgo: cryptoUtil.AlgoMD5,
+					}, nil).
 					Once()
 			},
 			wantErr: commonModel.PASSWORD_INCORRECT,
@@ -96,12 +122,21 @@ func TestLogin(t *testing.T) {
 		})
 	}
 
-	t.Run("success issues a non-empty token pair", func(t *testing.T) {
+	t.Run("success with bcrypt hash issues token pair without upgrade", func(t *testing.T) {
 		svc, repo, _, _ := newSvc(t, kvstore.NewMemory())
 		repo.EXPECT().
 			GetUserByUsername(mock.Anything, username).
-			Return(userModel.User{ID: "u-1", Username: username, Password: hashed}, nil).
+			Return(userModel.User{ID: userID, Username: username}, nil).
 			Once()
+		repo.EXPECT().
+			GetLocalAuthByUserID(mock.Anything, userID).
+			Return(userModel.UserLocalAuth{
+				UserID:       userID,
+				PasswordHash: bcryptHash,
+				PasswordAlgo: cryptoUtil.AlgoBcrypt,
+			}, nil).
+			Once()
+		// 已是 bcrypt：不应触发惰性升级写入（未对 UpdateLocalAuthPassword 设期望）。
 
 		pair, err := svc.Login(&authModel.LoginDto{Username: username, Password: plainPassword})
 		require.NoError(t, err)
@@ -109,6 +144,32 @@ func TestLogin(t *testing.T) {
 		assert.NotEmpty(t, pair.AccessToken)
 		assert.NotEmpty(t, pair.RefreshToken)
 		assert.Equal(t, config.Config().Auth.Jwt.Expires, pair.ExpiresIn)
+	})
+
+	t.Run("success with legacy md5 hash triggers lazy upgrade to bcrypt", func(t *testing.T) {
+		svc, repo, _, _ := newSvc(t, kvstore.NewMemory())
+		repo.EXPECT().
+			GetUserByUsername(mock.Anything, username).
+			Return(userModel.User{ID: userID, Username: username}, nil).
+			Once()
+		repo.EXPECT().
+			GetLocalAuthByUserID(mock.Anything, userID).
+			Return(userModel.UserLocalAuth{
+				UserID:       userID,
+				PasswordHash: md5Hash,
+				PasswordAlgo: cryptoUtil.AlgoMD5,
+			}, nil).
+			Once()
+		// 惰性升级：校验通过后就地换算为 bcrypt（bcrypt 哈希带随机盐、不确定，用 mock.Anything）。
+		repo.EXPECT().
+			UpdateLocalAuthPassword(mock.Anything, userID, mock.Anything, cryptoUtil.AlgoBcrypt).
+			Return(nil).
+			Once()
+
+		pair, err := svc.Login(&authModel.LoginDto{Username: username, Password: plainPassword})
+		require.NoError(t, err)
+		require.NotNil(t, pair)
+		assert.NotEmpty(t, pair.AccessToken)
 	})
 }
 

--- a/internal/service/auth/login_test.go
+++ b/internal/service/auth/login_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 // mustJSON 序列化任意值为 JSON 字符串，失败即终止用例。供本包多份测试文件共用。
@@ -85,7 +86,24 @@ func TestLogin(t *testing.T) {
 					Once()
 				repo.EXPECT().
 					GetLocalAuthByUserID(mock.Anything, userID).
-					Return(userModel.UserLocalAuth{}, errors.New("record not found")).
+					Return(userModel.UserLocalAuth{}, gorm.ErrRecordNotFound).
+					Once()
+			},
+			wantErr: commonModel.PASSWORD_INCORRECT,
+		},
+		{
+			// 真实 DB 故障（非 ErrRecordNotFound）应 fail-closed 为 PASSWORD_INCORRECT，
+			// 不泄露内部错误（并在实现里记 Warn，此处只断言对外行为）。
+			name: "local auth lookup db error maps to PASSWORD_INCORRECT",
+			dto:  authModel.LoginDto{Username: username, Password: plainPassword},
+			setupRepo: func(repo *authmock.MockRepository) {
+				repo.EXPECT().
+					GetUserByUsername(mock.Anything, username).
+					Return(userModel.User{ID: userID, Username: username}, nil).
+					Once()
+				repo.EXPECT().
+					GetLocalAuthByUserID(mock.Anything, userID).
+					Return(userModel.UserLocalAuth{}, errors.New("db down")).
 					Once()
 			},
 			wantErr: commonModel.PASSWORD_INCORRECT,

--- a/internal/service/auth/ports.go
+++ b/internal/service/auth/ports.go
@@ -40,6 +40,12 @@ type UserRepo interface {
 	GetUserByUsername(ctx context.Context, username string) (model.User, error)
 }
 
+// LocalAuthRepo 负责本地密码认证行（user_local_auth）的读取与惰性升级写入。
+type LocalAuthRepo interface {
+	GetLocalAuthByUserID(ctx context.Context, userID string) (model.UserLocalAuth, error)
+	UpdateLocalAuthPassword(ctx context.Context, userID, passwordHash, passwordAlgo string) error
+}
+
 type IdentityRepo interface {
 	BindOAuth(ctx context.Context, userID string, provider, oauthID, issuer, authType string) error
 	GetUserByOAuthID(ctx context.Context, provider, oauthID string) (model.User, error)
@@ -65,6 +71,7 @@ type ChallengeStore interface {
 
 type Repository interface {
 	UserRepo
+	LocalAuthRepo
 	IdentityRepo
 	PasskeyRepo
 	ChallengeStore

--- a/internal/service/file/file.go
+++ b/internal/service/file/file.go
@@ -192,7 +192,6 @@ func (s *FileService) UploadFile(
 		return commonModel.FileDto{}, err
 	}
 
-	user.Password = ""
 	if err := eventbus.Emit(
 		context.Background(),
 		s.bus,

--- a/internal/service/user/ports.go
+++ b/internal/service/user/ports.go
@@ -31,6 +31,7 @@ type UserRepo interface {
 	CreateUser(ctx context.Context, newUser *model.User) error
 	GetOwner(ctx context.Context) (model.User, error)
 	UpdateUser(ctx context.Context, user *model.User) error
+	UpsertLocalAuth(ctx context.Context, localAuth *model.UserLocalAuth) error
 	DeleteUser(ctx context.Context, id string) error
 }
 

--- a/internal/service/user/user.go
+++ b/internal/service/user/user.go
@@ -83,6 +83,12 @@ func (userService *UserService) InitOwner(registerDto *authModel.RegisterDto) er
 		}
 	}
 
+	// 对 owner 初始密码做 bcrypt 哈希，落入 user_local_auth。
+	passwordHash, err := cryptoUtil.HashPassword(registerDto.Password)
+	if err != nil {
+		return err
+	}
+
 	var owner model.User
 	if err := userService.transactor.Run(context.Background(), func(ctx context.Context) error {
 		initialized, err := userService.userRepository.IsInitialized(ctx)
@@ -110,13 +116,19 @@ func (userService *UserService) InitOwner(registerDto *authModel.RegisterDto) er
 		owner = model.User{
 			Username: registerDto.Username,
 			Email:    email,
-			Password: cryptoUtil.MD5Encrypt(registerDto.Password),
 			IsAdmin:  true,
 			IsOwner:  true,
 			Locale:   ownerLocale,
 		}
 
 		if err := userService.userRepository.CreateUser(ctx, &owner); err != nil {
+			return err
+		}
+		if err := userService.userRepository.UpsertLocalAuth(ctx, &model.UserLocalAuth{
+			UserID:       owner.ID,
+			PasswordHash: passwordHash,
+			PasswordAlgo: cryptoUtil.AlgoBcrypt,
+		}); err != nil {
 			return err
 		}
 
@@ -126,7 +138,6 @@ func (userService *UserService) InitOwner(registerDto *authModel.RegisterDto) er
 	}
 
 	// 发布用户注册事件（站点默认语言由 InitService 在编排层经 SettingService 落库，不在此处）。
-	owner.Password = "" // 不包含密码信息
 	eventbus.Notify(context.Background(), userService.bus, event.UserCreated{User: owner})
 
 	return nil
@@ -158,8 +169,11 @@ func (userService *UserService) Register(registerDto *authModel.RegisterDto) err
 		return errors.New(commonModel.USER_COUNT_EXCEED_LIMIT)
 	}
 
-	// 将密码进行 MD5 加密
-	registerDto.Password = cryptoUtil.MD5Encrypt(registerDto.Password)
+	// 对密码做 bcrypt 哈希，落入 user_local_auth（不再挂在 User 上）
+	passwordHash, err := cryptoUtil.HashPassword(registerDto.Password)
+	if err != nil {
+		return err
+	}
 	email := strings.TrimSpace(registerDto.Email)
 	if email != "" {
 		if _, err := mail.ParseAddress(email); err != nil {
@@ -170,7 +184,6 @@ func (userService *UserService) Register(registerDto *authModel.RegisterDto) err
 	newUser := model.User{
 		Username: registerDto.Username,
 		Email:    email,
-		Password: registerDto.Password,
 		IsAdmin:  false,
 		IsOwner:  false,
 		Locale:   string(commonModel.DefaultLocale),
@@ -194,14 +207,16 @@ func (userService *UserService) Register(registerDto *authModel.RegisterDto) err
 		if err := userService.userRepository.CreateUser(ctx, &newUser); err != nil {
 			return err
 		}
-
-		return nil
+		return userService.userRepository.UpsertLocalAuth(ctx, &model.UserLocalAuth{
+			UserID:       newUser.ID,
+			PasswordHash: passwordHash,
+			PasswordAlgo: cryptoUtil.AlgoBcrypt,
+		})
 	}); err != nil {
 		return err
 	}
 
 	// 发布用户注册事件
-	newUser.Password = "" // 不包含密码信息
 	eventbus.Notify(context.Background(), userService.bus, event.UserCreated{User: newUser})
 
 	return nil
@@ -237,14 +252,14 @@ func (userService *UserService) UpdateUser(ctx context.Context, userdto model.Us
 		user.Username = userdto.Username
 	}
 
-	// 检查是否需要更新密码
-	if userdto.Password != "" && cryptoUtil.MD5Encrypt(userdto.Password) != user.Password {
-		// 检查密码是否为空
-		if userdto.Password == "" {
-			return errors.New(commonModel.USERNAME_OR_PASSWORD_NOT_BE_EMPTY)
+	// 检查是否需要更新密码（改密写入 user_local_auth，不再挂在 User 上）
+	var newPasswordHash string
+	if userdto.Password != "" {
+		hashed, err := cryptoUtil.HashPassword(userdto.Password)
+		if err != nil {
+			return err
 		}
-		// 更新密码
-		user.Password = cryptoUtil.MD5Encrypt(userdto.Password)
+		newPasswordHash = hashed
 	}
 
 	avatarChanged := false
@@ -265,7 +280,18 @@ func (userService *UserService) UpdateUser(ctx context.Context, userdto model.Us
 	}
 	if err := userService.transactor.Run(ctx, func(txCtx context.Context) error {
 		// 更新用户信息
-		return userService.userRepository.UpdateUser(txCtx, &user)
+		if err := userService.userRepository.UpdateUser(txCtx, &user); err != nil {
+			return err
+		}
+		// 如有改密，写入 user_local_auth
+		if newPasswordHash != "" {
+			return userService.userRepository.UpsertLocalAuth(txCtx, &model.UserLocalAuth{
+				UserID:       user.ID,
+				PasswordHash: newPasswordHash,
+				PasswordAlgo: cryptoUtil.AlgoBcrypt,
+			})
+		}
+		return nil
 	}); err != nil {
 		return err
 	}
@@ -276,7 +302,6 @@ func (userService *UserService) UpdateUser(ctx context.Context, userdto model.Us
 	}
 
 	// 发布用户更新事件
-	user.Password = "" // 不包含密码信息
 	eventbus.Notify(context.Background(), userService.bus, event.UserUpdated{User: user})
 
 	return nil
@@ -323,17 +348,16 @@ func (userService *UserService) UpdateUserAdmin(ctx context.Context, id string) 
 	}
 
 	// 发布用户更新事件
-	user.Password = "" // 不包含密码信息
 	eventbus.Notify(context.Background(), userService.bus, event.UserUpdated{User: user})
 
 	return nil
 }
 
 // GetAllUsers 获取所有用户列表
-// 返回除 Owner 外的所有用户，并移除密码信息
+// 返回除 Owner 外的所有用户（用户实体已不含密码字段，密码存于 user_local_auth）
 //
 // 返回:
-//   - []model.User: 用户列表（不包含密码信息）
+//   - []model.User: 用户列表
 //   - error: 获取过程中的错误信息
 func (userService *UserService) GetAllUsers(ctx context.Context) ([]model.User, error) {
 	// Only Admin can get all users
@@ -362,11 +386,6 @@ func (userService *UserService) GetAllUsers(ctx context.Context) ([]model.User, 
 			allures = append(allures[:i], allures[i+1:]...)
 			break
 		}
-	}
-
-	// 处理用户信息(去掉密码)
-	for i := range allures {
-		allures[i].Password = ""
 	}
 
 	return allures, nil
@@ -429,7 +448,6 @@ func (userService *UserService) DeleteUser(ctx context.Context, id string) error
 		return err
 	}
 
-	deletedUser.Password = ""
 	eventbus.Notify(context.Background(), userService.bus, event.UserDeleted{User: deletedUser})
 	return nil
 }

--- a/internal/service/user/user.go
+++ b/internal/service/user/user.go
@@ -57,6 +57,15 @@ func NewUserService(
 	}
 }
 
+// ensurePasswordLength 在写入前拦掉超过 bcrypt 72 字节上限的口令，返回可本地化的业务错误，
+// 避免 bcrypt.GenerateFromPassword 抛出裸英文 ErrPasswordTooLong 直达前端。
+func ensurePasswordLength(password string) error {
+	if len(password) > cryptoUtil.MaxPasswordBytes {
+		return errors.New(commonModel.PASSWORD_TOO_LONG)
+	}
+	return nil
+}
+
 // InitOwner 初始化 Owner 账号
 //
 // 参数:
@@ -84,6 +93,9 @@ func (userService *UserService) InitOwner(registerDto *authModel.RegisterDto) er
 	}
 
 	// 对 owner 初始密码做 bcrypt 哈希，落入 user_local_auth。
+	if err := ensurePasswordLength(registerDto.Password); err != nil {
+		return err
+	}
 	passwordHash, err := cryptoUtil.HashPassword(registerDto.Password)
 	if err != nil {
 		return err
@@ -170,6 +182,9 @@ func (userService *UserService) Register(registerDto *authModel.RegisterDto) err
 	}
 
 	// 对密码做 bcrypt 哈希，落入 user_local_auth（不再挂在 User 上）
+	if err := ensurePasswordLength(registerDto.Password); err != nil {
+		return err
+	}
 	passwordHash, err := cryptoUtil.HashPassword(registerDto.Password)
 	if err != nil {
 		return err
@@ -255,6 +270,9 @@ func (userService *UserService) UpdateUser(ctx context.Context, userdto model.Us
 	// 检查是否需要更新密码（改密写入 user_local_auth，不再挂在 User 上）
 	var newPasswordHash string
 	if userdto.Password != "" {
+		if err := ensurePasswordLength(userdto.Password); err != nil {
+			return err
+		}
 		hashed, err := cryptoUtil.HashPassword(userdto.Password)
 		if err != nil {
 			return err

--- a/internal/service/user/user_guards_test.go
+++ b/internal/service/user/user_guards_test.go
@@ -152,18 +152,25 @@ func TestInitOwner_Success(t *testing.T) {
 
 	var created userModel.User
 	m.repo.EXPECT().CreateUser(mock.Anything, mock.Anything).
-		Run(func(_ context.Context, u *userModel.User) { created = *u }).
+		Run(func(_ context.Context, u *userModel.User) { u.ID = "owner-id"; created = *u }).
+		Return(nil).Once()
+	var localAuth userModel.UserLocalAuth
+	m.repo.EXPECT().UpsertLocalAuth(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, la *userModel.UserLocalAuth) { localAuth = *la }).
 		Return(nil).Once()
 	m.repo.EXPECT().MarkInitialized(mock.Anything).Return(nil).Once()
 
 	err := svc.InitOwner(&authModel.RegisterDto{Username: "owner", Password: "secret", Email: " owner@ech0.com "})
 	require.NoError(t, err)
 
-	// 首位用户必须被提权为 Owner+Admin，密码经 MD5 落库，邮箱被 trim。
+	// 首位用户必须被提权为 Owner+Admin，邮箱被 trim。
 	assert.True(t, created.IsOwner, "first user must be owner")
 	assert.True(t, created.IsAdmin, "owner must be admin")
-	assert.Equal(t, cryptoUtil.MD5Encrypt("secret"), created.Password)
 	assert.Equal(t, "owner@ech0.com", created.Email)
+	// 密码以 bcrypt 存入 user_local_auth，并绑定到新建 owner 的 ID。
+	assert.Equal(t, "owner-id", localAuth.UserID)
+	assert.Equal(t, cryptoUtil.AlgoBcrypt, localAuth.PasswordAlgo)
+	assert.True(t, cryptoUtil.CheckPassword(localAuth.PasswordAlgo, localAuth.PasswordHash, "secret"))
 }
 
 // ---------------------------------------------------------------------------
@@ -241,7 +248,11 @@ func TestRegister_Success(t *testing.T) {
 
 	var created userModel.User
 	m.repo.EXPECT().CreateUser(mock.Anything, mock.Anything).
-		Run(func(_ context.Context, u *userModel.User) { created = *u }).
+		Run(func(_ context.Context, u *userModel.User) { u.ID = "newbie-id"; created = *u }).
+		Return(nil).Once()
+	var localAuth userModel.UserLocalAuth
+	m.repo.EXPECT().UpsertLocalAuth(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, la *userModel.UserLocalAuth) { localAuth = *la }).
 		Return(nil).Once()
 
 	err := svc.Register(&authModel.RegisterDto{Username: "newbie", Password: "pw"})
@@ -250,7 +261,10 @@ func TestRegister_Success(t *testing.T) {
 	// 普通注册用户绝不能携带管理员/站长身份（提权守卫）。
 	assert.False(t, created.IsAdmin, "registered user must not be admin")
 	assert.False(t, created.IsOwner, "registered user must not be owner")
-	assert.Equal(t, cryptoUtil.MD5Encrypt("pw"), created.Password)
+	// 密码以 bcrypt 存入 user_local_auth。
+	assert.Equal(t, "newbie-id", localAuth.UserID)
+	assert.Equal(t, cryptoUtil.AlgoBcrypt, localAuth.PasswordAlgo)
+	assert.True(t, cryptoUtil.CheckPassword(localAuth.PasswordAlgo, localAuth.PasswordHash, "pw"))
 }
 
 // ---------------------------------------------------------------------------
@@ -414,15 +428,12 @@ func TestGetAllUsers_NotAdmin(t *testing.T) {
 	assert.Nil(t, got)
 }
 
-func TestGetAllUsers_StripsOwnerAndPasswords(t *testing.T) {
+func TestGetAllUsers_StripsOwner(t *testing.T) {
 	svc, m := newUserSvc(t)
 
 	owner := helpers.NewUser(withID("owner-1"), helpers.AsOwner)
-	owner.Password = "owner-secret"
 	admin := helpers.NewUser(withID("admin-1"), helpers.AsAdmin)
-	admin.Password = "admin-secret"
 	normal := helpers.NewUser(withID("u-2"))
-	normal.Password = "user-secret"
 
 	// 调用者为 admin。
 	m.repo.EXPECT().GetUserByID(mock.Anything, "admin-1").Return(admin, nil).Once()
@@ -436,7 +447,6 @@ func TestGetAllUsers_StripsOwnerAndPasswords(t *testing.T) {
 	require.Len(t, got, 2, "owner 必须被剔除")
 	for _, u := range got {
 		assert.NotEqual(t, owner.ID, u.ID, "结果中不应出现 owner")
-		assert.Empty(t, u.Password, "密码必须被剥离")
 	}
 }
 

--- a/internal/service/user/user_guards_test.go
+++ b/internal/service/user/user_guards_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	authModel "github.com/lin-snow/ech0/internal/model/auth"
@@ -265,6 +266,28 @@ func TestRegister_Success(t *testing.T) {
 	assert.Equal(t, "newbie-id", localAuth.UserID)
 	assert.Equal(t, cryptoUtil.AlgoBcrypt, localAuth.PasswordAlgo)
 	assert.True(t, cryptoUtil.CheckPassword(localAuth.PasswordAlgo, localAuth.PasswordHash, "pw"))
+}
+
+func TestRegister_PasswordTooLong(t *testing.T) {
+	svc, m := newUserSvc(t)
+	m.repo.EXPECT().IsInitialized(mock.Anything).Return(true, nil).Once()
+	m.repo.EXPECT().GetAllUsers(mock.Anything).Return(nil, nil).Once()
+	// 超过 bcrypt 72 字节上限应在哈希/建号前被拦下（GetUserByUsername/CreateUser 都不应被触达）。
+
+	longPw := strings.Repeat("a", cryptoUtil.MaxPasswordBytes+1)
+	err := svc.Register(&authModel.RegisterDto{Username: "u", Password: longPw})
+	require.EqualError(t, err, commonModel.PASSWORD_TOO_LONG)
+}
+
+func TestUpdateUser_PasswordTooLong(t *testing.T) {
+	svc, m := newUserSvc(t)
+	// 操作者为 admin，改自己的资料；超长密码应在写库前被拒。
+	m.repo.EXPECT().GetUserByID(mock.Anything, "admin-1").
+		Return(helpers.NewUser(withID("admin-1"), helpers.AsAdmin), nil).Once()
+
+	longPw := strings.Repeat("a", cryptoUtil.MaxPasswordBytes+1)
+	err := svc.UpdateUser(helpers.CtxAsUser("admin-1"), userModel.UserInfoDto{Password: longPw})
+	require.EqualError(t, err, commonModel.PASSWORD_TOO_LONG)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/test/helpers/fixtures.go
+++ b/internal/test/helpers/fixtures.go
@@ -13,7 +13,6 @@ func NewUser(opts ...func(*userModel.User)) userModel.User {
 	u := userModel.User{
 		ID:       "user-test-0001",
 		Username: "tester",
-		Password: "hashed-password",
 	}
 	for _, o := range opts {
 		o(&u)

--- a/internal/test/mocks/authmock/mocks.go
+++ b/internal/test/mocks/authmock/mocks.go
@@ -1466,6 +1466,72 @@ func (_c *MockRepository_DeletePasskeyByID_Call) RunAndReturn(run func(ctx conte
 	return _c
 }
 
+// GetLocalAuthByUserID provides a mock function for the type MockRepository
+func (_mock *MockRepository) GetLocalAuthByUserID(ctx context.Context, userID string) (model0.UserLocalAuth, error) {
+	ret := _mock.Called(ctx, userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetLocalAuthByUserID")
+	}
+
+	var r0 model0.UserLocalAuth
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (model0.UserLocalAuth, error)); ok {
+		return returnFunc(ctx, userID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) model0.UserLocalAuth); ok {
+		r0 = returnFunc(ctx, userID)
+	} else {
+		r0 = ret.Get(0).(model0.UserLocalAuth)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepository_GetLocalAuthByUserID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetLocalAuthByUserID'
+type MockRepository_GetLocalAuthByUserID_Call struct {
+	*mock.Call
+}
+
+// GetLocalAuthByUserID is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+func (_e *MockRepository_Expecter) GetLocalAuthByUserID(ctx any, userID any) *MockRepository_GetLocalAuthByUserID_Call {
+	return &MockRepository_GetLocalAuthByUserID_Call{Call: _e.mock.On("GetLocalAuthByUserID", ctx, userID)}
+}
+
+func (_c *MockRepository_GetLocalAuthByUserID_Call) Run(run func(ctx context.Context, userID string)) *MockRepository_GetLocalAuthByUserID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_GetLocalAuthByUserID_Call) Return(userLocalAuth model0.UserLocalAuth, err error) *MockRepository_GetLocalAuthByUserID_Call {
+	_c.Call.Return(userLocalAuth, err)
+	return _c
+}
+
+func (_c *MockRepository_GetLocalAuthByUserID_Call) RunAndReturn(run func(ctx context.Context, userID string) (model0.UserLocalAuth, error)) *MockRepository_GetLocalAuthByUserID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetOAuthInfo provides a mock function for the type MockRepository
 func (_mock *MockRepository) GetOAuthInfo(userId string, provider string) (model0.UserExternalIdentity, error) {
 	ret := _mock.Called(userId, provider)
@@ -2004,6 +2070,75 @@ func (_c *MockRepository_ListPasskeysByUserID_Call) Return(passkeys []model.Pass
 }
 
 func (_c *MockRepository_ListPasskeysByUserID_Call) RunAndReturn(run func(userID string) ([]model.Passkey, error)) *MockRepository_ListPasskeysByUserID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateLocalAuthPassword provides a mock function for the type MockRepository
+func (_mock *MockRepository) UpdateLocalAuthPassword(ctx context.Context, userID string, passwordHash string, passwordAlgo string) error {
+	ret := _mock.Called(ctx, userID, passwordHash, passwordAlgo)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateLocalAuthPassword")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, string) error); ok {
+		r0 = returnFunc(ctx, userID, passwordHash, passwordAlgo)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockRepository_UpdateLocalAuthPassword_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateLocalAuthPassword'
+type MockRepository_UpdateLocalAuthPassword_Call struct {
+	*mock.Call
+}
+
+// UpdateLocalAuthPassword is a helper method to define mock.On call
+//   - ctx context.Context
+//   - userID string
+//   - passwordHash string
+//   - passwordAlgo string
+func (_e *MockRepository_Expecter) UpdateLocalAuthPassword(ctx any, userID any, passwordHash any, passwordAlgo any) *MockRepository_UpdateLocalAuthPassword_Call {
+	return &MockRepository_UpdateLocalAuthPassword_Call{Call: _e.mock.On("UpdateLocalAuthPassword", ctx, userID, passwordHash, passwordAlgo)}
+}
+
+func (_c *MockRepository_UpdateLocalAuthPassword_Call) Run(run func(ctx context.Context, userID string, passwordHash string, passwordAlgo string)) *MockRepository_UpdateLocalAuthPassword_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_UpdateLocalAuthPassword_Call) Return(err error) *MockRepository_UpdateLocalAuthPassword_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockRepository_UpdateLocalAuthPassword_Call) RunAndReturn(run func(ctx context.Context, userID string, passwordHash string, passwordAlgo string) error) *MockRepository_UpdateLocalAuthPassword_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/test/mocks/usermock/mocks.go
+++ b/internal/test/mocks/usermock/mocks.go
@@ -942,6 +942,63 @@ func (_c *MockUserRepo_UpdateUser_Call) RunAndReturn(run func(ctx context.Contex
 	return _c
 }
 
+// UpsertLocalAuth provides a mock function for the type MockUserRepo
+func (_mock *MockUserRepo) UpsertLocalAuth(ctx context.Context, localAuth *model.UserLocalAuth) error {
+	ret := _mock.Called(ctx, localAuth)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertLocalAuth")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.UserLocalAuth) error); ok {
+		r0 = returnFunc(ctx, localAuth)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockUserRepo_UpsertLocalAuth_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertLocalAuth'
+type MockUserRepo_UpsertLocalAuth_Call struct {
+	*mock.Call
+}
+
+// UpsertLocalAuth is a helper method to define mock.On call
+//   - ctx context.Context
+//   - localAuth *model.UserLocalAuth
+func (_e *MockUserRepo_Expecter) UpsertLocalAuth(ctx any, localAuth any) *MockUserRepo_UpsertLocalAuth_Call {
+	return &MockUserRepo_UpsertLocalAuth_Call{Call: _e.mock.On("UpsertLocalAuth", ctx, localAuth)}
+}
+
+func (_c *MockUserRepo_UpsertLocalAuth_Call) Run(run func(ctx context.Context, localAuth *model.UserLocalAuth)) *MockUserRepo_UpsertLocalAuth_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *model.UserLocalAuth
+		if args[1] != nil {
+			arg1 = args[1].(*model.UserLocalAuth)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUserRepo_UpsertLocalAuth_Call) Return(err error) *MockUserRepo_UpsertLocalAuth_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockUserRepo_UpsertLocalAuth_Call) RunAndReturn(run func(ctx context.Context, localAuth *model.UserLocalAuth) error) *MockUserRepo_UpsertLocalAuth_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockInstallStateRepo creates a new instance of MockInstallStateRepo. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockInstallStateRepo(t interface {
@@ -1639,6 +1696,63 @@ func (_c *MockRepository_UpdateUser_Call) Return(err error) *MockRepository_Upda
 }
 
 func (_c *MockRepository_UpdateUser_Call) RunAndReturn(run func(ctx context.Context, user *model.User) error) *MockRepository_UpdateUser_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpsertLocalAuth provides a mock function for the type MockRepository
+func (_mock *MockRepository) UpsertLocalAuth(ctx context.Context, localAuth *model.UserLocalAuth) error {
+	ret := _mock.Called(ctx, localAuth)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpsertLocalAuth")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.UserLocalAuth) error); ok {
+		r0 = returnFunc(ctx, localAuth)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockRepository_UpsertLocalAuth_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpsertLocalAuth'
+type MockRepository_UpsertLocalAuth_Call struct {
+	*mock.Call
+}
+
+// UpsertLocalAuth is a helper method to define mock.On call
+//   - ctx context.Context
+//   - localAuth *model.UserLocalAuth
+func (_e *MockRepository_Expecter) UpsertLocalAuth(ctx any, localAuth any) *MockRepository_UpsertLocalAuth_Call {
+	return &MockRepository_UpsertLocalAuth_Call{Call: _e.mock.On("UpsertLocalAuth", ctx, localAuth)}
+}
+
+func (_c *MockRepository_UpsertLocalAuth_Call) Run(run func(ctx context.Context, localAuth *model.UserLocalAuth)) *MockRepository_UpsertLocalAuth_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *model.UserLocalAuth
+		if args[1] != nil {
+			arg1 = args[1].(*model.UserLocalAuth)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_UpsertLocalAuth_Call) Return(err error) *MockRepository_UpsertLocalAuth_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockRepository_UpsertLocalAuth_Call) RunAndReturn(run func(ctx context.Context, localAuth *model.UserLocalAuth) error) *MockRepository_UpsertLocalAuth_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/util/crypto/crypto.go
+++ b/internal/util/crypto/crypto.go
@@ -7,14 +7,46 @@ import (
 	"crypto/md5"
 	"crypto/rand"
 	"encoding/hex"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
-// MD5Encrypt 对内容进行 MD5 编码
+// 密码哈希算法标识，持久化在 user_local_auth.password_algo 列，登录时据此分派校验。
+const (
+	AlgoMD5    = "md5"    // 历史遗留：裸 MD5 无盐，仅用于存量校验，登录成功后惰性升级为 bcrypt
+	AlgoBcrypt = "bcrypt" // 当前算法：自带盐、自描述哈希串
+)
+
+// MD5Encrypt 对内容进行 MD5 编码。
+//
+// 已废弃用于新密码——仅保留给存量 AlgoMD5 口令的校验（见 CheckPassword）。
 func MD5Encrypt(text string) string {
 	hash := md5.New()
 	hash.Write([]byte(text))
 	hashInBytes := hash.Sum(nil)
 	return hex.EncodeToString(hashInBytes)
+}
+
+// HashPassword 用 bcrypt（默认 cost，自带随机盐）对明文口令做哈希，返回自描述的哈希串。
+// 返回的哈希应连同 AlgoBcrypt 一起持久化到 user_local_auth。
+func HashPassword(plain string) (string, error) {
+	hashed, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hashed), nil
+}
+
+// CheckPassword 校验明文口令是否匹配存储的哈希，按 algo 分派：
+//   - AlgoBcrypt：bcrypt 常数时间比对；
+//   - 其它（AlgoMD5 或空串等存量值）：退化为裸 MD5 等值比对。
+//
+// 校验通过且 algo != AlgoBcrypt 时，调用方应惰性升级为 bcrypt。
+func CheckPassword(algo, storedHash, plain string) bool {
+	if algo == AlgoBcrypt {
+		return bcrypt.CompareHashAndPassword([]byte(storedHash), []byte(plain)) == nil
+	}
+	return MD5Encrypt(plain) == storedHash
 }
 
 // randomCharset 是 GenerateRandomString 使用的字符集（62 个字符）。

--- a/internal/util/crypto/crypto.go
+++ b/internal/util/crypto/crypto.go
@@ -17,6 +17,10 @@ const (
 	AlgoBcrypt = "bcrypt" // 当前算法：自带盐、自描述哈希串
 )
 
+// MaxPasswordBytes 是 bcrypt 接受的口令字节上限——超过 72 字节 GenerateFromPassword 会返回
+// ErrPasswordTooLong。写入侧据此前置校验，避免把 bcrypt 的裸英文错误抛给用户。
+const MaxPasswordBytes = 72
+
 // MD5Encrypt 对内容进行 MD5 编码。
 //
 // 已废弃用于新密码——仅保留给存量 AlgoMD5 口令的校验（见 CheckPassword）。

--- a/internal/util/crypto/crypto_test.go
+++ b/internal/util/crypto/crypto_test.go
@@ -27,6 +27,33 @@ func TestMD5Encrypt(t *testing.T) {
 	}
 }
 
+func TestHashPassword_RoundTrip(t *testing.T) {
+	const plain = "s3cr3t-pw"
+	hash, err := HashPassword(plain)
+	require.NoError(t, err)
+	// bcrypt 自描述哈希串，带随机盐：以 $2 开头，且两次哈希不相等。
+	assert.True(t, strings.HasPrefix(hash, "$2"), "want bcrypt hash, got %q", hash)
+	other, err := HashPassword(plain)
+	require.NoError(t, err)
+	assert.NotEqual(t, hash, other, "bcrypt 每次应产生不同盐")
+
+	// 以 bcrypt 算法校验：正确口令通过，错误口令拒绝。
+	assert.True(t, CheckPassword(AlgoBcrypt, hash, plain))
+	assert.False(t, CheckPassword(AlgoBcrypt, hash, "wrong-pw"))
+}
+
+func TestCheckPassword_LegacyMD5(t *testing.T) {
+	const plain = "old-pw"
+	md5Hash := MD5Encrypt(plain)
+
+	// 存量 md5 算法：正确口令通过，错误口令拒绝。
+	assert.True(t, CheckPassword(AlgoMD5, md5Hash, plain))
+	assert.False(t, CheckPassword(AlgoMD5, md5Hash, "nope"))
+
+	// 空算法（历史未标记）应退化为 md5 比对，保证老数据仍可登录。
+	assert.True(t, CheckPassword("", md5Hash, plain))
+}
+
 func TestGenerateRandomString_Length(t *testing.T) {
 	for _, n := range []int{1, 8, 16, 32, 64, 256} {
 		got := GenerateRandomString(n)


### PR DESCRIPTION
## Summary

本地密码此前以**裸 MD5、无盐**存在 `users.password`，登录是字符串等值比对——一旦拖库即被彩虹表/GPU 秒破。同时 Ech0 已有四种认证，但结构不对称：OAuth2/OIDC 在 `user_external_identities`、Passkey 在 `webauthn_credentials`，唯独本地密码内联在 `users` 上（`user_local_auth` 表早已建好却从未接线）。

本 PR 把本地密码迁入它本该待的 `user_local_auth` 表，`users` 从此不含任何密钥，与其余认证方式架构对齐；并把哈希算法升级为 **bcrypt**（自带盐、自描述）。存量用户**下次登录时惰性透明升级**（md5 → bcrypt），无需重置、不打扰。

主要改动：

- **crypto**：新增 `HashPassword` / `CheckPassword`，按 `password_algo`（`md5` | `bcrypt`）分派校验；`MD5Encrypt` 降级为仅供存量校验。
- **model**：删除 `User.Password` 字段，`users` 不再承载任何密钥。
- **repository**：`AuthRepository` 加 `GetLocalAuthByUserID` / `UpdateLocalAuthPassword`；`UserRepository` 加 `UpsertLocalAuth`，`DeleteUser` 级联清理本地认证行。
- **service**：登录改读 `user_local_auth` + `CheckPassword`，校验通过后对非 bcrypt 存量哈希就地惰性升级（best-effort，升级写失败不阻断登录）；注册 / 初始化 / 改密写入 `user_local_auth`；清理迁走后失效的密码脱敏代码。
- **migration**：幂等回填（`users.password` → `user_local_auth`，算法标记 `md5`），随后删除 `users.password` 遗留列——二者均以标记键幂等、并以 `HasColumn` 守卫（新库自动 no-op）。

## Type of change

- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Refactor (no behavior change)
- [ ] Docs
- [ ] Build / CI / chore
- [ ] Breaking change

## Area

- [x] Backend / API
- [ ] Frontend / UI
- [x] Auth / Access tokens
- [ ] Storage (local / S3)
- [ ] Webhook / Agent / Events
- [x] Migration / Backup
- [ ] Hub / Connect
- [ ] Docs

## How to verify

```bash
# 单测（重点包）
go test ./internal/util/crypto/... ./internal/service/auth/... \
        ./internal/service/user/... ./internal/repository/... \
        ./internal/database/migration/...
# 全量
go build ./... && go test ./...
```

覆盖到的行为：
- **crypto**：bcrypt 往返、存量 md5（含空算法）校验、错密码拒绝。
- **登录**：bcrypt 成功不触发升级 / md5 成功触发一次惰性升级 / 无 `user_local_auth` 行 → 密码错 / 错密码 → 密码错。
- **迁移**：回填 + 幂等（不覆盖已升级的 bcrypt、不产生重复行）+ 无 `password` 列时 no-op；**删列对真实 AutoMigrate 出来的 `users` 表（带 unique 索引）验证通过**——本 PR 最高风险步骤。
- **仓储**：真实 SQLite 往返 `UpsertLocalAuth`（含 `ON CONFLICT` 更新）、读取、更新、删除级联。

端到端（可选，reviewer 复核）：
1. **新库**：删 `data/*.db` → 起服务 → 初始化 owner + 注册 + 登录成功；`users` 应**无 `password` 列**、`user_local_auth` 有 `$2...` bcrypt 行。
2. **存量升级**：造旧库（`users.password` 填某明文的 32 位 MD5、无 `user_local_auth` 行）→ 启动跑迁移 → 用该明文登录成功，登录后该行 `password_algo` 变 `bcrypt`、hash 变 `$2...`；重启不重复迁移。

## Impact

- **数据迁移**：启动时自动执行，幂等。回填先于删列（`WithStopOnError` 保证顺序）。旧库 `users.password` 被删除、密码搬入 `user_local_auth`。
- **兼容性**：存量账号登录行为不变，下次登录自动升级为 bcrypt；不需要任何人重置密码。当前不存在"无本地密码账号"（OAuth/Passkey 从不建号），回填全覆盖。
- **回滚**：迁移是前向的（删列不可逆）。回滚到旧版本前需先备份快照；旧版本读不到已迁走的密码，故回滚需谨慎（建议先在快照上验证）。
- **无 DI / API 形状变化**：`make wire` / `make openapi` 重跑均**零 diff**。
- **无前端 / i18n 改动**。

## Pre-submission checklist

- [x] 后端门禁本地全绿：`make fmt` / `make lint`（0 issues）/ `make openapi`（无 diff）/ `make wire-check`（无 diff）/ `make spdx-check`（0 缺失）/ `make test`。web 部分未跑（本 PR 无前端改动，web 目录未变）。
- [x] `go build ./...` 通过。
- [ ] `pnpm build` —— 不适用（无前端改动）。
- [x] 行为变更已补测试（crypto / login / 注册·改密 / 回填·删列 migrator / 仓储真实 DB 往返）。
- [x] `make wire` 已重跑，`wire_gen.go` 无变化（无 DI provider/binding 改动）。
- [x] OpenAPI 已重跑（`make openapi` → `internal/openapi/openapi.yaml`），无 diff（无路由/请求响应形状变化）。*注：模板里的 `make swagger` / `internal/swagger/` 为旧称。*
- [x] 无需文档改动（内部存储重构，用户/部署无感）。
- [x] 无硬编码 UI 字符串（后端改动，`pnpm i18n:check` 不受影响）。
- [x] diff / 日志 / 截图中无密钥、token 或个人数据（惰性升级日志仅记 `user_id`，不含哈希或明文）。
