### PR TITLE
docs(readme): fix the broken star history chart

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -275,11 +275,11 @@ Besonderen Dank an die [LinuxDO](https://linux.do/) Community für ihre Anerkenn
 
 ## Star-Verlauf
 
-<a href="https://www.star-history.com/?repos=lin-snow%2FEch0&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#lin-snow/Ech0&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
  </picture>
 </a>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -275,11 +275,11 @@ Docker Compose や Helm を使った手順は [かんたんデプロイ](#かん
 
 ## Star ヒストリー
 
-<a href="https://www.star-history.com/?repos=lin-snow%2FEch0&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#lin-snow/Ech0&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -295,11 +295,11 @@ Special thanks to the [LinuxDO](https://linux.do/) community for their recogniti
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=lin-snow%2FEch0&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#lin-snow/Ech0&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
  </picture>
 </a>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -278,11 +278,11 @@ docker run -d \
 
 ## Star 增长曲线
 
-<a href="https://www.star-history.com/?repos=lin-snow%2FEch0&type=timeline&legend=top-left">
+<a href="https://star-history.dera.page/#lin-snow/Ech0&type=timeline&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=lin-snow/Ech0&type=timeline&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
Hi,

The star history chart in the README is currently broken: GitHub stargazer API restrictions took down the service that was rendering it, so the chart shows nothing on the repository page. Since the star history is one of the first things visitors look at, fixing it is necessary.

This MR updates the chart in the main README and its Chinese, Japanese, and German translations to point to a working endpoint, so the chart renders correctly again in all four versions.